### PR TITLE
Server parameters can now be defined in api.auth()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ const api = new ScreepsAPI({
   email: 'screeps@email.com',
   password: 'notMyPass',
   protocol: 'https',
-  host: 'screeps.com',
+  hostname: 'screeps.com',
   port: 443,
   path: '/' // Do no include '/api', it will be added automatically
 });
 
-api.auth('screeps@email.com','notMyPass')
+// You can overwrite parameters if needed
+api.auth('screeps@email.com','notMyPass',{
+  protocol: 'https',
+  hostname: 'screeps.com',
+  port: 443,
+  path: '/' // Do no include '/api', it will be added automatically
+})
 
 // Dump Memory
 api.memory.get()

--- a/src/ScreepsAPI.js
+++ b/src/ScreepsAPI.js
@@ -1,11 +1,9 @@
-import { format } from 'url'
-import { EventEmitter } from 'events'
 import { Socket } from './Socket'
 import { RawAPI } from './RawAPI'
 
 const DEFAULTS = {
   protocol: 'https',
-  host: 'screeps.com',
+  hostname: 'screeps.com',
   port: 443,
   path: '/'
 }
@@ -13,12 +11,7 @@ const DEFAULTS = {
 export class ScreepsAPI extends RawAPI {
   constructor(opts){
     opts = Object.assign({},DEFAULTS,opts)
-    if(!opts.url){
-      opts.pathname = opts.pathname || opts.path
-      opts.url = format(opts)
-    }
     super(opts)
-    this.opts = opts
     this.on('token',(token)=>{
       this.token = token
       this.raw.token = token


### PR DESCRIPTION
Change `apit.auth()` (and other functions) to allow overwriting server parameters defined when constructing API (or set by default).