### PR TITLE
Added PTR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ const api = new ScreepsAPI({
   protocol: 'https',
   hostname: 'screeps.com',
   port: 443,
+  ptr: false,
   path: '/' // Do no include '/api', it will be added automatically
 });
 
@@ -26,6 +27,7 @@ api.auth('screeps@email.com','notMyPass',{
   protocol: 'https',
   hostname: 'screeps.com',
   port: 443,
+  ptr: false,
   path: '/' // Do no include '/api', it will be added automatically
 })
 

--- a/src/RawAPI.js
+++ b/src/RawAPI.js
@@ -189,7 +189,7 @@ export class RawAPI extends EventEmitter {
         },
         code: {
           get(branch){
-            return self.req('GET',`${self.opts.apiPath}/api/user/code`, { branch })
+            return self.req('GET',`${self.opts.apiPath}/user/code`, { branch })
           },
           set(branch,modules,_hash){
             if(!_hash) _hash = Date.now()

--- a/src/RawAPI.js
+++ b/src/RawAPI.js
@@ -15,10 +15,10 @@ export class RawAPI extends EventEmitter {
     let self = this
     this.raw = {
       version(){
-        return self.req('GET','/api/version')
+        return self.req('GET',`${self.opts.apiPath}/version`)
       },
       authmod(){
-        if(this.opts.url.match(/screeps\.com/))
+        if(self.opts.url.match(/screeps\.com/))
           return Promise.resolve({ name: 'official' })
         return self.req('GET','/authmod')
       },
@@ -28,213 +28,213 @@ export class RawAPI extends EventEmitter {
       },
       auth: {
         signin(email,password){
-          return self.req('POST','/api/auth/signin', { email,password })
+          return self.req('POST',`${self.opts.apiPath}/auth/signin`, { email,password })
         },
         steamTicket(ticket,useNativeAuth=false){
-          return self.req('POST','/api/auth/steam-ticket', { ticket, useNativeAuth })
+          return self.req('POST',`${self.opts.apiPath}/auth/steam-ticket`, { ticket, useNativeAuth })
         },
         me(){
-          return self.req('GET','/api/auth/me')
+          return self.req('GET',`${self.opts.apiPath}/auth/me`)
         },
       },
       register: {
         checkEmail(email){
-          return self.req('GET','/api/register/check-email', { email })
+          return self.req('GET',`${self.opts.apiPath}/register/check-email`, { email })
         },
         checkUsername(username){
-          return self.req('GET','/api/register/check-username', { username })
+          return self.req('GET',`${self.opts.apiPath}/register/check-username`, { username })
         },
         setUsername(username){
-          return self.req('POST','/api/register/set-username', { username })
+          return self.req('POST',`${self.opts.apiPath}/register/set-username`, { username })
         },
         submit(username,email,password,modules){
-          return self.req('POST','/api/register/submit', { username, email, password, modules })
+          return self.req('POST',`${self.opts.apiPath}/register/submit`, { username, email, password, modules })
         }
       },
       userMessages: {
         list(respondent){
-          return self.req('GET','/api/user-messages/list', { respondent })
+          return self.req('GET',`${self.opts.apiPath}/user-messages/list`, { respondent })
         },
         index(){
-          return self.req('GET','/api/user-messages/index')
+          return self.req('GET',`${self.opts.apiPath}/user-messages/index`)
         },
         unreadCount(){
-          return self.req('GET','/api/user-messages/unread-count')
+          return self.req('GET',`${self.opts.apiPath}/user-messages/unread-count`)
         },
         send(respondent,text){
-          return self.req('POST','/api/user-messages/send', { respondent, text })
+          return self.req('POST',`${self.opts.apiPath}/user-messages/send`, { respondent, text })
         },
         markRead(id){
-          return self.req('POST','/api/user-messages/mark-read', { id })
+          return self.req('POST',`${self.opts.apiPath}/user-messages/mark-read`, { id })
         },
       },
       game: {
         mapStats(rooms,statName){
-          return self.req('POST','/api/game/map-stats', { rooms, statName })
+          return self.req('POST',`${self.opts.apiPath}/game/map-stats`, { rooms, statName })
         },
         genUniqueObjectName(type){
-          return self.req('POST','/api/game/gen-unique-object-name', { type })
+          return self.req('POST',`${self.opts.apiPath}/game/gen-unique-object-name`, { type })
         },
         checkUniqueObjectName(type,name){
-          return self.req('POST','/api/game/check-unique-object-name', { type, name })
+          return self.req('POST',`${self.opts.apiPath}/game/check-unique-object-name`, { type, name })
         },
         placeSpawn(room,x,y,name){
-          return self.req('POST','/api/game/place-spawn', { name, room, x, y })
+          return self.req('POST',`${self.opts.apiPath}/game/place-spawn`, { name, room, x, y })
         },
         createFlag(room,x,y,name,color=1,secondaryColor=1){
-          return self.req('POST','/api/game/create-flag', { name, room, x, y, color, secondaryColor })
+          return self.req('POST',`${self.opts.apiPath}/game/create-flag`, { name, room, x, y, color, secondaryColor })
         },
         genUniqueFlagName(){
-          return self.req('POST','/api/game/gen-unique-flag-name')
+          return self.req('POST',`${self.opts.apiPath}/game/gen-unique-flag-name`)
         },
         checkUniqueFlagName(name){
-          return self.req('POST','/api/game/check-unique-flag-name', { name })
+          return self.req('POST',`${self.opts.apiPath}/game/check-unique-flag-name`, { name })
         },
         changeFlagColor(color=1,secondaryColor=1){
-          return self.req('POST','/api/game/change-flag-color', { color, secondaryColor })
+          return self.req('POST',`${self.opts.apiPath}/game/change-flag-color`, { color, secondaryColor })
         },
         removeFlag(room,name){
-          return self.req('POST','/api/game/remove-flag',{ name, room })
+          return self.req('POST',`${self.opts.apiPath}/game/remove-flag`,{ name, room })
         },
         addObjectIntent(room,name,intent){
-          return self.req('POST','/api/game/add-object-intent', { room, name, intent })
+          return self.req('POST',`${self.opts.apiPath}/game/add-object-intent`, { room, name, intent })
         },
         createConstruction(room,x,y,structureType,name){
-          return self.req('POST','/api/game/create-construction', { room, x, y, structureType, name })
+          return self.req('POST',`${self.opts.apiPath}/game/create-construction`, { room, x, y, structureType, name })
         },
         setNotifyWhenAttacked(_id, enabled=true){
-          return self.req('POST','/api/game/set-notify-when-attacked', { _id, enabled })
+          return self.req('POST',`${self.opts.apiPath}/game/set-notify-when-attacked`, { _id, enabled })
         },
         createInvader(room,x,y,size,type,boosted=false){
-          return self.req('POST','/api/game/create-invader', { room, x, y, size, type, boosted })
+          return self.req('POST',`${self.opts.apiPath}/game/create-invader`, { room, x, y, size, type, boosted })
         },
         removeInvader(_id){
-          return self.req('POST','/api/game/remove-invader',{ _id })
+          return self.req('POST',`${self.opts.apiPath}/game/remove-invader`,{ _id })
         },
         time(){
-          return self.req('GET','/api/game/time')
+          return self.req('GET',`${self.opts.apiPath}/game/time`)
         },
         worldSize(){
-          return self.req('GET','/api/game/world-size')
+          return self.req('GET',`${self.opts.apiPath}/game/world-size`)
         },
         roomTerrain(room,encoded=1){
-          return self.req('GET','/api/game/room-terrain', { room, encoded })
+          return self.req('GET',`${self.opts.apiPath}/game/room-terrain`, { room, encoded })
         },
         roomStatus(room){
-          return self.req('GET','/api/game/room-status', { room })
+          return self.req('GET',`${self.opts.apiPath}/game/room-status`, { room })
         },
         roomOverview(room,interval=8){
-          return self.req('GET','/api/game/room-overview', { room, interval })
+          return self.req('GET',`${self.opts.apiPath}/game/room-overview`, { room, interval })
         },
         market: {
           ordersIndex(){
-            return self.req('GET','/api/game/market/orders-index')
+            return self.req('GET',`${self.opts.apiPath}/game/market/orders-index`)
           },
           myOrders(){
-            return self.req('GET','/api/game/market/my-orders')
+            return self.req('GET',`${self.opts.apiPath}/game/market/my-orders`)
           },
           orders(resourceType){
-            return self.req('GET','/api/game/market/orders', { resourceType })
+            return self.req('GET',`${self.opts.apiPath}/game/market/orders`, { resourceType })
           },
           stats(resourceType){
-            return self.req('GET','/api/game/market/stats', { resourceType })
+            return self.req('GET',`${self.opts.apiPath}/game/market/stats`, { resourceType })
           }
         },
       },
       leaderboard: {
         list(){
-          return self.req('GET','/api/leaderboard/list')
+          return self.req('GET',`${self.opts.apiPath}/leaderboard/list`)
         },
         find(username,mode='world',season=''){
-          return self.req('GET','/api/leaderboard/find', { season, mode, username })
+          return self.req('GET',`${self.opts.apiPath}/leaderboard/find`, { season, mode, username })
         },
         seasons(){
-          return self.req('GET','/api/leaderboard/seasons')
+          return self.req('GET',`${self.opts.apiPath}/leaderboard/seasons`)
         }
       },
       user:{
         badge(badge){
-          return self.req('POST','/api/user/badge', { badge })
+          return self.req('POST',`${self.opts.apiPath}/user/badge`, { badge })
         },
         respawn(){
-          return self.req('POST','/api/user/respawn')
+          return self.req('POST',`${self.opts.apiPath}/user/respawn`)
         },
         setActiveBranch(branch,activeName){
-          return self.req('POST','/api/user/set-active-branch', { branch, activeName })
+          return self.req('POST',`${self.opts.apiPath}/user/set-active-branch`, { branch, activeName })
         },
         cloneBranch(branch,newName,defaultModules){
-          return self.req('POST','/api/user/clone-branch', { branch, newName, defaultModules })
+          return self.req('POST',`${self.opts.apiPath}/user/clone-branch`, { branch, newName, defaultModules })
         },
         deleteBranch(branch){
-          return self.req('POST','/api/user/delete-branch', { branch })
+          return self.req('POST',`${self.opts.apiPath}/user/delete-branch`, { branch })
         },
         notifyPrefs(prefs){
           // disabled,disabledOnMessages,sendOnline,interval,errorsInterval
-          return self.req('POST','/api/user/notify-prefs', prefs)
+          return self.req('POST',`${self.opts.apiPath}/user/notify-prefs`, prefs)
         },
         tutorialDone(){
-          return self.req('POST','/api/user/tutorial-done')
+          return self.req('POST',`${self.opts.apiPath}/user/tutorial-done`)
         },
         email(email){
-          return self.req('POST','/api/user/email', { email })
+          return self.req('POST',`${self.opts.apiPath}/user/email`, { email })
         },
         worldStartRoom(){
-          return self.req('GET','/api/user/world-start-room')
+          return self.req('GET',`${self.opts.apiPath}/user/world-start-room`)
         },
         worldStatus(){
-          return self.req('GET','/api/user/world-status')
+          return self.req('GET',`${self.opts.apiPath}/user/world-status`)
         },
         branches(){
-          return self.req('GET','/api/user/branches')
+          return self.req('GET',`${self.opts.apiPath}/user/branches`)
         },
         code: {
           get(branch){
-            return self.req('GET','/api/user/code', { branch })
+            return self.req('GET',`${self.opts.apiPath}/api/user/code`, { branch })
           },
           set(branch,modules,_hash){
             if(!_hash) _hash = Date.now()
-            return self.req('POST','/api/user/code', { branch, modules, _hash })
+            else return self.req('POST',`${self.opts.apiPath}/user/code`, { branch, modules, _hash })
           }
         },
         respawnProhibitedRooms(){
-          return self.req('GET','/api/user/respawn-prohibited-rooms')
+          return self.req('GET',`${self.opts.apiPath}/user/respawn-prohibited-rooms`)
         },
         memory:{
           get(path){
-            return self.req('GET','/api/user/memory', { path })
+            return self.req('GET',`${self.opts.apiPath}/user/memory`, { path })
           },
           set(path,value){
-            return self.req('POST','/api/user/memory', { path, value })
+            return self.req('POST',`${self.opts.apiPath}/user/memory`, { path, value })
           },
           segment:{
             get(segment){
-              return self.req('GET','/api/user/memory-segment', { segment })
+              return self.req('GET',`${self.opts.apiPath}/user/memory-segment`, { segment })
             },
             set(segment,data){
-              return self.req('POST','/api/user/memory-segment', { segment, data })
+              return self.req('POST',`${self.opts.apiPath}/user/memory-segment`, { segment, data })
             },
           }
         },
         find(username){
-          return self.req('GET','/api/user/find', { username })
+          return self.req('GET',`${self.opts.apiPath}/user/find`, { username })
         },
         findById(id){
-          return self.req('GET','/api/user/find', { id })
+          return self.req('GET',`${self.opts.apiPath}/user/find`, { id })
         },
         stats(interval){
-          return self.req('GET','/api/user/stats', { interval })
+          return self.req('GET',`${self.opts.apiPath}/user/stats`, { interval })
         },
         rooms(id){
-          return self.req('GET','/api/user/rooms', { id })
+          return self.req('GET',`${self.opts.apiPath}/user/rooms`, { id })
         },
         overview(interval,statName){
-          return self.req('GET','/api/user/overview', { interval, statName })
+          return self.req('GET',`${self.opts.apiPath}/user/overview`, { interval, statName })
         },
         moneyHistory(page=0){
-          return self.req('GET','/api/user/money-history', { page })
+          return self.req('GET',`${self.opts.apiPath}/user/money-history`, { page })
         },
         console(expression){
-          return self.req('POST','/api/user/console', { expression })
+          return self.req('POST',`${self.opts.apiPath}/user/console`, { expression })
         },
       }
     }
@@ -248,6 +248,7 @@ export class RawAPI extends EventEmitter {
       this.opts.pathname = this.opts.pathname || this.opts.path
       this.opts.url = format(this.opts)
     }
+    this.opts.apiPath = this.opts.ptr ? "/ptr/api" : "/api"
   }
   async auth(email,password,opts={}){
     this.setServer(opts)

--- a/src/RawAPI.js
+++ b/src/RawAPI.js
@@ -193,7 +193,7 @@ export class RawAPI extends EventEmitter {
           },
           set(branch,modules,_hash){
             if(!_hash) _hash = Date.now()
-            else return self.req('POST',`${self.opts.apiPath}/user/code`, { branch, modules, _hash })
+            return self.req('POST',`${self.opts.apiPath}/user/code`, { branch, modules, _hash })
           }
         },
         respawnProhibitedRooms(){


### PR DESCRIPTION
Added an option `ptr` which allows to access public test realms (and especially the official one).
* Add option `ptr`  in constructor (and `auth()`) ; it is false by default
* Each time new options are set, defines `opts.apiPath` to `/api` or `/ptr/api`
* Raw endpoints now use `opts.apiPath` instead of plain `/api`

Also fixed an error in `authmod()` where screeps URL was never checked.