### PR TITLE
Auto-reconnect fix

### DIFF
--- a/src/Socket.js
+++ b/src/Socket.js
@@ -54,7 +54,10 @@ export class Socket extends EventEmitter {
         this.connected = false
         this.emit('disconnected')
         if (this.opts.reconnect) {
-          this.reconnect()
+          this.reconnect().catch(() => {
+            let err = new Error(`Auto-reconnect failed after ${this.maxRetries} retries`)
+            this.emit('error', err)
+          });
         } else {
           this.removeAllListeners()
         }

--- a/src/Socket.js
+++ b/src/Socket.js
@@ -6,7 +6,7 @@ const DEFAULTS = {
   reconnect: true,
   resubscribe: true,
   keepAlive: true,
-  maxTries: 5
+  maxRetries: 5
 }
 
 export class Socket extends EventEmitter {

--- a/src/Socket.js
+++ b/src/Socket.js
@@ -54,10 +54,7 @@ export class Socket extends EventEmitter {
         this.connected = false
         this.emit('disconnected')
         if (this.opts.reconnect) {
-          this.reconnect().catch(() => {
-            let err = new Error(`Auto-reconnect failed after ${this.maxRetries} retries`)
-            this.emit('error', err)
-          });
+          this.reconnect().catch(() => { /* error emitted in reconnect() */ });
         } else {
           this.removeAllListeners()
         }
@@ -93,7 +90,7 @@ export class Socket extends EventEmitter {
       retries++
     } while (retry && retries < this.maxRetries)
     if (retry) {
-      let err = new Error(`Too many connection failures ${this.maxRetries}`)
+      let err = new Error(`Reconnection failed after ${this.maxRetries} retries`)
       this.emit('error', err)
       throw err
     }


### PR DESCRIPTION
Fix for `api.socket.reconnect()` when using auto reconection.
Typical error example:
```
(node:17211) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Too many connection failures undefined
```