### PR TITLE
Socket disconnection proposal

### DIFF
--- a/src/Socket.js
+++ b/src/Socket.js
@@ -101,6 +101,7 @@ export class Socket extends EventEmitter {
     } while (retry && retries < this.opts.maxRetries)
     if (retry) {
       let err = new Error(`Reconnection failed after ${this.opts.maxRetries} retries`)
+      this.reconnecting = false
       this.emit('error', err)
       throw err
     }

--- a/src/Socket.js
+++ b/src/Socket.js
@@ -32,8 +32,8 @@ export class Socket extends EventEmitter {
     this.authed = false
     this.connected = false
     this.reconnecting = false
-    this.keepAliveInter = 0
     clearInterval(this.keepAliveInter)
+    this.keepAliveInter = 0
     this.__queue = []    // pending messages  (to send once authenticated)
     this.__subQueue = [] // pending subscriptions (to request once authenticated)
     this.__subs = {}     // number of callbacks for each subscription
@@ -83,6 +83,7 @@ export class Socket extends EventEmitter {
   }
   async reconnect () {
     Object.keys(this.__subs).forEach(sub => this.subscribe(sub))
+    this.reconnecting = true
     let retries = 0
     let retry
     do {

--- a/src/Socket.js
+++ b/src/Socket.js
@@ -49,6 +49,7 @@ export class Socket extends EventEmitter {
       this.ws = new WebSocket(wsurl)
       this.ws.on('open', () => {
         this.connected = true
+        this.reconnecting = false
         if (this.opts.resubscribe) {
           this.__subQueue.push(...Object.keys(this.__subs))
         }


### PR DESCRIPTION
Socket now exports `disconnect()` function which:
- reset most internal states ;
- clear ongoing timers and reconnections ;
- remove events attached to the underlying websocket ;
- `terminate()` the connection ;
- ... and emit `disconnected`.

Subscriptions and pending messages are also deleted.