### PR TITLE
Removed socket.removeAllListeners() after a websocket close event.

### DIFF
--- a/src/Socket.js
+++ b/src/Socket.js
@@ -63,8 +63,6 @@ export class Socket extends EventEmitter {
         this.emit('disconnected')
         if (this.opts.reconnect) {
           this.reconnect().catch(() => { /* error emitted in reconnect() */ });
-        } else {
-          this.removeAllListeners()
         }
       })
       this.ws.on('error', (err) => {


### PR DESCRIPTION
I don't think there is any case when removing listeners would actually be useful.
- If the user added his own callbacks, it's his job to remove them and clearly not ours to delete them.
- If there `.then()` was called on `connect()`, it should be either rejected or resolved by the time we hit `close` event. And it wouldn't be detached by `removeAllListeners()` anyway.

On the other hand, `removeAllListeners()` removes callbacks defined in constructor and potential subscription callbacks which will never be reattached again.