### PR TITLE
Bumped maxRetries to 10 and added maxRetryDelay option.

### DIFF
--- a/src/Socket.js
+++ b/src/Socket.js
@@ -6,7 +6,8 @@ const DEFAULTS = {
   reconnect: true,
   resubscribe: true,
   keepAlive: true,
-  maxRetries: 5
+  maxRetries: 10,
+  maxRetryDelay: 60 * 1000 // in milli-seconds
 }
 
 export class Socket extends EventEmitter {
@@ -87,6 +88,7 @@ export class Socket extends EventEmitter {
     let retry
     do {
       let time = Math.pow(2, retries) * 100
+      if(time > this.opts.maxRetryDelay) time = this.opts.maxRetryDelay
       await this.sleep(time)
       if (!this.reconnecting) return; // reset() called in-between
       try {


### PR DESCRIPTION
Reconnection delay looked like too low to reconnect to screeps.com sometimes.
Now, socket tries to reconnect 10 times with up to 1 minute delay (by default).