### PR TITLE
api.auth() not using saved credentials

### DIFF
--- a/src/RawAPI.js
+++ b/src/RawAPI.js
@@ -261,8 +261,10 @@ export class RawAPI extends EventEmitter {
       this.opts = {}
     }
     Object.assign(this.opts, opts)
+    if (opts.path && !opts.pathname) {
+      this.opts.pathname = this.opts.path
+    }
     if (!opts.url) {
-      this.opts.pathname = this.opts.pathname || this.opts.path
       this.opts.url = format(this.opts)
     }
   }

--- a/src/RawAPI.js
+++ b/src/RawAPI.js
@@ -271,7 +271,7 @@ export class RawAPI extends EventEmitter {
     if (email && password) {
       Object.assign(this.opts, { email, password })
     }
-    let res = await this.raw.auth.signin(email, password)
+    let res = await this.raw.auth.signin(this.opts.email, this.opts.password)
     this.emit('token', res.token)
     this.emit('auth')
     this.__authed = true


### PR DESCRIPTION
If user and password were specified in constructor and not in the actual `auth()` call, api should use saved options.