### PR TITLE
Increased tests timeout.

### DIFF
--- a/test/api.general.js
+++ b/test/api.general.js
@@ -6,6 +6,7 @@ const auth = require('./credentials')
 describe('ScreepsAPI', function() {
 
   this.slow(2000);
+  this.timeout(5000);
 
   describe('.constructor()', function() {
     it('should save passed options', function() {

--- a/test/api.raw.auth.js
+++ b/test/api.raw.auth.js
@@ -6,6 +6,7 @@ const auth = require('./credentials')
 describe('api.raw.auth', function() {
 
   this.slow(2000);
+  this.timeout(5000);
 
   describe('.signin (email, password)', function() {
     it('should send a POST request to /api/auth/signin and authenticate', async function() {

--- a/test/api.raw.game.js
+++ b/test/api.raw.game.js
@@ -6,6 +6,7 @@ const auth = require('./credentials')
 describe('api.raw.userMessages', function() {
 
   this.slow(2000);
+  this.timeout(5000);
 
   describe('.mapStats (rooms, statName, shard = DEFAULT_SHARD)', function() {
     it('should do untested things (for now)')

--- a/test/api.raw.general.js
+++ b/test/api.raw.general.js
@@ -6,6 +6,7 @@ const auth = require('./credentials')
 describe('api.raw', function() {
 
   this.slow(2000);
+  this.timeout(5000);
 
   describe('.version()', function() {
     it('should call /api/version endpoint and return version information', async function() {

--- a/test/api.raw.leaderboard.js
+++ b/test/api.raw.leaderboard.js
@@ -6,6 +6,7 @@ const auth = require('./credentials')
 describe('api.raw.leaderboard', function() {
 
   this.slow(2000);
+  this.timeout(5000);
 
   describe('.list ()', function() {
     it('should do untested things (for now)')

--- a/test/api.raw.register.js
+++ b/test/api.raw.register.js
@@ -6,6 +6,7 @@ const auth = require('./credentials')
 describe('api.raw.register', function() {
 
   this.slow(2000);
+  this.timeout(5000);
 
   describe('.checkEmail (email)', function() {
     it('should do untested things (for now)')

--- a/test/api.raw.user.js
+++ b/test/api.raw.user.js
@@ -6,6 +6,7 @@ const auth = require('./credentials')
 describe('api.raw.user', function() {
 
   this.slow(3000);
+  this.timeout(5000);
 
   describe('.badge (badge)', function() {
     it('should send a request to /api/user/badge which sets user badge',  async function() {

--- a/test/api.raw.userMessage.js
+++ b/test/api.raw.userMessage.js
@@ -6,6 +6,7 @@ const auth = require('./credentials')
 describe('api.raw.userMessages', function() {
 
   this.slow(2000);
+  this.timeout(5000);
 
   describe('.list (respondent)', function() {
     it('should do untested things (for now)')

--- a/test/credentials.js
+++ b/test/credentials.js
@@ -5,3 +5,12 @@ module.exports = {
     hostname: 'server1.screepspl.us',
     port:     443,
 };
+/*
+module.exports = {
+    username: 'ryanis.shadow@gmail.com',
+    password: '61f2d5454d9ea0a131e9ac319b46aadb712563a06e9d670846f24aec1063e5ce', // official
+    protocol: 'https',
+    hostname: 'screeps.com',
+    port:     443,
+};
+*/


### PR DESCRIPTION
Some tests are randomly failing because they excess the default 2 seconds timeout.
This fix increases it up to 5 seconds.