### PR TITLE
Fixes gunzip of data

### DIFF
--- a/src/RawAPI.js
+++ b/src/RawAPI.js
@@ -354,8 +354,8 @@ export class RawAPI extends EventEmitter {
       const rateLimit = this.buildRateLimit(method, path, res)
       this.emit('rateLimit', rateLimit)
       debugRateLimit(`${method} ${path} ${rateLimit.remaining}/${rateLimit.limit} ${rateLimit.toReset}s`)
-      if (typeof res.data === 'string' && res.data.slice(0, 3) === 'gz:') {
-        res.data = await this.gz(res.data)
+      if (typeof res.data.data === 'string' && res.data.data.slice(0, 3) === 'gz:') {
+        res.data.data = await this.gz(res.data.data)
       }
       this.emit('response', res)
       return res.data


### PR DESCRIPTION
During the transition to Axios it looks like the unzipping of data was broken. 

Prior to Axios, the (possibly zipped) response data was "lifted" by `res = res.json()` so that `res.data` referred to the zipped element. Now the same element would be `res.data.data`.

This corrects the references to the possibly zipped data element.