### PR TITLE
Update bufferutil and utf-8-validate to fix errors on node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "yamljs": "^0.3.0"
   },
   "optionalDependencies": {
-    "bufferutil": "^3.0.5",
-    "utf-8-validate": "^4.0.2"
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": "^5.0.2"
   },
   "devDependencies": {
     "lodash": "^4.17.11",


### PR DESCRIPTION
Fixes #54.
