### PR TITLE
Show error message if connect fails with no response

### DIFF
--- a/src/RawAPI.js
+++ b/src/RawAPI.js
@@ -982,7 +982,10 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
         await sleep(Math.floor(Math.random() * 500) + 200)
         return this.req(method, path, body)
       }
-      throw new Error(res.data)
+      if (err.response) {
+        throw new Error(res.data);
+      }
+      throw err;
     }
   }
 

--- a/src/RawAPI.js
+++ b/src/RawAPI.js
@@ -985,7 +985,7 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
       if (err.response) {
         throw new Error(res.data);
       }
-      throw err;
+      throw new Error(err.message);
     }
   }
 


### PR DESCRIPTION
If connect completely fails with no response it throws an unhelpful Error with no message:

```
Error
    at ScreepsAPI.req (/home/simon/screeps/node_modules/screeps-api/dist/ScreepsAPI.js:1214:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

This PR changes it to use the error message from axios if there was no response:

```
Error: connect ECONNREFUSED 192.168.8.2:21025
    at ScreepsAPI.req (/home/simon/github/node-screeps-api/dist/ScreepsAPI.js:1217:13)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```