### PR TITLE
feat: export config in opts

### DIFF
--- a/src/ScreepsAPI.js
+++ b/src/ScreepsAPI.js
@@ -27,11 +27,10 @@ export class ScreepsAPI extends RawAPI {
         Object.assign(
           {
             hostname: conf.host,
-            port: conf.port,
             protocol: conf.secure ? 'https' : 'http',
-            token: conf.token,
-            path: conf.path || '/'
+            path: '/'
           },
+          conf,
           opts
         )
       )


### PR DESCRIPTION
Allows to get additional fields from config like `branch`.

Currently you need to `yaml.parse` the config file manually to get those.

With config:
```yaml
servers:
  main:
    host: screeps.com
    secure: true
    token: xxxx
    branch: v2
```

```js
const api = await ScreepsAPI.fromConfig()
console.log(api.opts.branch)
```