### PR TITLE
Update module format to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "screeps-api",
   "version": "2.0.0",
   "description": "",
-  "repository": "screepers/node-screeps-api",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/screepers/node-screeps-api.git"
+  },
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "bin": {
@@ -27,8 +31,7 @@
     "node": "22.x || 24.x"
   },
   "files": [
-    "dist/**/*",
-    "LICENSE"
+    "dist/**/*"
   ],
   "dependencies": {
     "axios": "^1.16.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,6 +1,7 @@
+import { defineConfig } from 'rollup';
 import typescript from 'rollup-plugin-typescript2'
 
-export default {
+export default defineConfig({
   input: {
     cli: 'bin/screeps-api.ts',
     index: 'src/index.ts',
@@ -8,7 +9,7 @@ export default {
   },
   output: {
     dir: 'dist',
-    format: 'cjs',
+    format: 'esm',
     globals: {
       ws: 'WebSocket'
     },
@@ -33,4 +34,4 @@ export default {
   plugins: [
     typescript()
   ]
-}
+})


### PR DESCRIPTION
Addresses https://github.com/screepers/node-screeps-api/issues/90 .
For context, see https://github.com/screepers/node-screeps-api/pull/89 .

Breaking changes:
* Updated bundle format to ESM, which breaks compatibility with CJS projects

Cleanup:
* Added `defineConfig` wrapper to Rollup config
* Updated `package.json` via `npm pkg fix` and testing with `npm pack`.