### PR TITLE
Refactor configuration and authentication logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ auth.js
 dist
 npm-debug.log
 
+screeps.json
 .screeps.json
 .screeps.yml
 .screeps.yaml

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -45,6 +45,7 @@ declare global {
       /** Client version number; undefined on non-official servers */
       package?: number
       protocol: number
+      databaseVersion?: number
       serverData: {
         customObjectTypes: object
         /** Number of ticks in each complete history file/chunk */

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -1,27 +1,37 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
+import URL from 'node:url'
 import { parse } from 'yaml'
+
+const DEFAULT_SERVER_HOST = 'screeps.com'
+const DEFAULT_SERVER_PATH = '/'
 
 export class ConfigManager {
   path?: string
-  private _config?: Api.YamlConfig | null
+  private _config?: Api.Config | null
 
-  async refresh() {
+  async refresh(serverName: string) {
     this._config = null
-    await this.getConfig()
+    await this.getConfig(serverName)
   }
 
-  async getServers(): Promise<string[]> {
-    const conf = await this.getConfig()
-    return Object.keys(conf?.servers ?? [])
-  }
-
-  async getConfig(): Promise<Api.YamlConfig | null> {
+  /**
+   * Search for config files and load
+   * @param opts see {@link LoadConfigOptions}
+   * @returns a valid {@link Api.Config} if one was found, or null
+   */
+  async getConfig(
+    serverName: string,
+    opts?: Api.LoadConfigOptions
+  ): Promise<Api.Config | null> {
     if (this._config) {
       return this._config
     }
     const paths = []
+    if (opts?.file) {
+      paths.push(opts.file)
+    }
     if (process.env.SCREEPS_CONFIG) {
       paths.push(process.env.SCREEPS_CONFIG)
     }
@@ -29,10 +39,13 @@ export class ConfigManager {
     for (const dir of dirs) {
       paths.push(path.join(dir, '.screeps.yaml'))
       paths.push(path.join(dir, '.screeps.yml'))
+      paths.push(path.join(dir, '.screeps.json'))
+      paths.push(path.join(dir, 'screeps.json'))
     }
     if (process.platform === 'win32' && process.env.APPDATA) {
       paths.push(path.join(process.env.APPDATA, 'screeps/config.yaml'))
       paths.push(path.join(process.env.APPDATA, 'screeps/config.yml'))
+      paths.push(path.join(process.env.APPDATA, 'screeps/screeps.json'))
     } else {
       if (process.env.XDG_CONFIG_HOME) {
         paths.push(
@@ -41,16 +54,21 @@ export class ConfigManager {
         paths.push(
           path.join(process.env.XDG_CONFIG_HOME, 'screeps/config.yml')
         )
+        paths.push(
+          path.join(process.env.XDG_CONFIG_HOME, 'screeps/screeps.json')
+        )
       }
       if (process.env.HOME) {
         paths.push(path.join(process.env.HOME, '.config/screeps/config.yaml'))
         paths.push(path.join(process.env.HOME, '.config/screeps/config.yml'))
         paths.push(path.join(process.env.HOME, '.screeps.yaml'))
         paths.push(path.join(process.env.HOME, '.screeps.yml'))
+        paths.push(path.join(process.env.HOME, '.screeps.json'))
+        paths.push(path.join(process.env.HOME, 'screeps.json'))
       }
     }
     for (const path of paths) {
-      const data = await this.loadConfig(path)
+      const data = await this.loadNormalizedConfig(path, serverName, opts)
       if (data) {
         this._config = data
         this.path = path
@@ -61,16 +79,43 @@ export class ConfigManager {
     return null
   }
 
-  async loadConfig(file: string): Promise<Api.YamlConfig | null> {
+  async loadNormalizedConfig(
+    file: string,
+    serverName: string,
+    opts?: Api.LoadConfigOptions
+  ): Promise<Api.Config | null> {
+    const parsed = await this.loadConfig(file)
+    if (!parsed) {
+      return null
+    }
+
+    return {
+      client: this.normalizeClientConfig(parsed, file, opts),
+      server: this.normalizeServersConfig(parsed, file, serverName),
+      parsed
+    }
+  }
+
+  async loadConfig(file: string): Promise<Api.JsonConfig | Api.YamlConfig | null> {
     try {
       const contents = await readFile(file, { encoding: 'utf8' })
-      const data = parse(contents) as Api.YamlConfig
-      if (!data.servers) {
-        throw new Error(
-          `Invalid config: 'servers' object does not exist in '${path}'`
-        )
+      if (!file.endsWith('.json')) {
+        const data = parse(contents) as Api.YamlConfig
+        if (!data.servers) {
+          throw new Error(
+            `Invalid config: 'servers' object does not exist in '${file}'`
+          )
+        }
+        return data
+      } else {
+        const data = JSON.parse(contents) as unknown
+        if (typeof data !== 'object' || Array.isArray(data)) {
+          throw new Error(
+            `Invalid config: found '${typeof data}' instead of a JSON object at '${file}'`
+          )
+        }
+        return data as Api.JsonConfig
       }
-      return data
     } catch (e) {
       if ((e as { code?: string }).code === 'ENOENT') {
         return null
@@ -79,26 +124,159 @@ export class ConfigManager {
       }
     }
   }
+
+  normalizeServersConfig(
+    parsed: Api.JsonConfig | Api.YamlConfig,
+    file: string,
+    serverName: string
+  ): Api.ServerConfig {
+    const servers = ('servers' in parsed) ? parsed.servers as Api.JsonConfig : parsed
+    const rawServer = servers[serverName]
+    if (!rawServer) {
+      const list = Object.keys(servers).join(', ')
+      throw new Error(
+        `Invalid config: server ${serverName} not found in in ${file}; servers defined in this config: ${list}`
+      )
+    }
+
+    return this.normalizeServerConfig(rawServer)
+  }
+
+  normalizeServerConfig(rawServer: Api.RawServerConfig): Api.ServerConfig {
+    let url = rawServer.url
+    if (!url) {
+      rawServer.protocol ??= (rawServer.secure !== false ? 'https' : 'http')
+      rawServer.hostname ??= rawServer.host ?? DEFAULT_SERVER_HOST
+      rawServer.port ??= rawServer.protocol === 'https' ? 443 : 80
+      rawServer.pathname ??= rawServer.path
+        ?? (rawServer.ptr ? '/ptr' : undefined)
+        ?? (rawServer.season ? '/season' : undefined)
+        ?? DEFAULT_SERVER_PATH
+      url = URL.format({
+        protocol: rawServer.protocol,
+        hostname: rawServer.hostname,
+        port: rawServer.port,
+        pathname: rawServer.pathname
+      })
+    }
+    if (!url.endsWith('/')) url += '/'
+
+    const server: Api.ServerConfig = { url }
+
+    if (rawServer.token) {
+      Object.assign(server, { token: rawServer.token })
+    } else if (rawServer.email && rawServer.password) {
+      Object.assign(
+        server,
+        {
+          email: rawServer.email,
+          password: rawServer.password
+        }
+      )
+    } else {
+      throw new Error(
+        `Invalid config: server config must contain either token or email/password fields`
+      )
+    }
+
+    return server
+  }
+
+  normalizeClientConfig(
+    parsed: Api.JsonConfig | Api.YamlConfig,
+    file: string,
+    opts?: Api.LoadConfigOptions
+  ): Api.ClientConfig {
+    const client: Api.ClientConfig = {}
+    if (!opts?.client) {
+      return client
+    }
+
+    if (typeof opts.client === 'object') {
+      Object.assign(client, opts.client)
+      return client
+    }
+
+    if (typeof opts.client === 'string') {
+      const appName = opts.client
+      const appConfigs = (parsed as Api.YamlConfig).configs
+      const appConfig = appConfigs?.[appName]
+
+      if (typeof appConfig !== 'object') {
+        Object.assign(client, appConfig)
+      } else {
+        console.warn(`Could not find config '${appName}' in '${file}'; using default client config`)
+      }
+
+      return client
+    }
+
+    console.warn(`Invalid config name '${opts.client}'; using default client config`)
+    return client
+  }
 }
 
 declare global {
   namespace Api {
-    /**
-     * Format of a screeps unified credential file:
-     * https://github.com/screepers/screepers-standards/blob/3877e86f38caed9891ef6270aa9690df556e6c22/SS3-Unified_Credentials_File.md
-     */
-    interface YamlConfig {
-      servers: { [serverName: string]: ServerConfig | undefined }
-      configs?: { [appName: string]: AppConfig | undefined }
+    /** Configuration and options for a {@link ScreepsAPI} client */
+    interface Config {
+      /** @see {@link ClientConfig} */
+      client: ClientConfig
+      /**
+       * Configuration for the Screeps World server to which this client
+       * should connect
+       */
+      server: Readonly<ServerConfig>
+      /**
+       * The config file parsed (but not normalized) by {@link ConfigManager}.
+       * Apps can use this to determine which other server names and client
+       * configs are available.
+       */
+      parsed?: JsonConfig | YamlConfig
     }
 
-    /** Format of a screeps.json credential file */
-    interface JsonConfig {
-      [serverName: string]: ServerConfig | undefined
+    interface LoadConfigOptions {
+      /**
+       * Specifies the path of the screeps YAML or JSON credential file to use.
+       * If defined, this takes precedence over the `SCREEPS_CONFIG` env var.
+       */
+      file?: string
+      /**
+       * If this is a string and a YAML credential file is used,
+       * {@link ClientConfig} will be pulled from the `configs[client]` key
+       * in that file.
+       */
+      client?: string | ClientConfig
     }
 
-    /** Configuration for a single Screeps World server */
+    /** Normalized configuration for a single Screeps World server */
     interface ServerConfig {
+      url: string
+      token?: string
+      email?: string
+      password?: string
+    }
+
+    /**
+     * User-configurable options for a {@link ScreepsAPI} client.
+     * `ClientConfig` objects may also contain custom configuration options
+     * intended for apps using {@link ScreepsAPI}.
+     */
+    type ClientConfig = {
+      /**
+       * Specifies a default shard name to use when one is not provided
+       * as an argument to a {@link ScreepsAPI} endpoint function
+       */
+      defaultShard?: string
+      /**
+       * Automatically retry requests that fail due to rate limiting
+       * @default true
+       */
+      retry429?: boolean
+    } & { [propertyName: string]: unknown }
+
+    /** Server configuration schema from {@link JsonConfig}/{@link YamlConfig} */
+    interface RawServerConfig {
       token?: string
       email?: string
       username?: string
@@ -113,11 +291,20 @@ declare global {
       url?: string
       ptr?: boolean
       season?: boolean
-      /** Automatically retry requests that fail due to rate limiting */
-      experimentalRetry429?: boolean
     }
 
-    /** Application-level configuration from {@link YamlConfig} */
-    interface AppConfig { [propertyName: string]: unknown }
+    /**
+     * Format of a screeps unified credential file:
+     * https://github.com/screepers/screepers-standards/blob/3877e86f38caed9891ef6270aa9690df556e6c22/SS3-Unified_Credentials_File.md
+     */
+    interface YamlConfig {
+      servers: { [serverName: string]: Api.RawServerConfig | undefined }
+      configs?: { [appName: string]: Api.ClientConfig | undefined }
+    }
+
+    /** Format of a screeps.json credential file */
+    interface JsonConfig {
+      [serverName: string]: Api.RawServerConfig | undefined
+    }
   }
 }

--- a/src/RawAPI.ts
+++ b/src/RawAPI.ts
@@ -3,7 +3,6 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import Debug from 'debug'
 import { EventEmitter } from 'node:events'
 import { setTimeout } from 'node:timers/promises'
-import URL from 'node:url'
 import utils from 'node:util'
 import zlib from 'zlib'
 import { FlagColor } from './Api'
@@ -11,12 +10,9 @@ import { FlagColor } from './Api'
 const debugHttp = Debug('screepsapi:http')
 const debugRateLimit = Debug('screepsapi:ratelimit')
 
-const { format } = URL
-
 const gunzipAsync = utils.promisify(zlib.gunzip)
 const inflateAsync = utils.promisify(zlib.inflate)
 
-const DEFAULT_SHARD = 'shard0'
 const OFFICIAL_HISTORY_INTERVAL = 100
 const PRIVATE_HISTORY_INTERVAL = 20
 
@@ -42,7 +38,8 @@ export class RawAPI extends EventEmitter {
      * GET /room-history
      * @returns A json file with history data
      */
-    history: (room: string, tick: number, shard = DEFAULT_SHARD): Promise<Api.RoomHistoryResponse> => {
+    history: (room: string, tick: number, shard?: string): Promise<Api.RoomHistoryResponse> => {
+      shard ??= this.config.client.defaultShard
       if (this.isOfficialServer()) {
         tick -= tick % OFFICIAL_HISTORY_INTERVAL
         return this.req('GET', `/room-history/${shard}/${room}/${tick}.json`)
@@ -122,7 +119,11 @@ export class RawAPI extends EventEmitter {
        * @param statName the ID of the stat to fetch
        * @param shard
        */
-      mapStats: async <S extends Api.MapStat>(rooms: string[], statName: S, shard = DEFAULT_SHARD): Promise<Api.GameMapStatsResponse<S>> => {
+      mapStats: async <S extends Api.MapStat>(rooms: string[], statName: S, shard?: string): Promise<Api.GameMapStatsResponse<S>> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/map-stats', { rooms, statName, shard })
       },
 
@@ -131,17 +132,29 @@ export class RawAPI extends EventEmitter {
        * @param type the type of object for which to generate the name (ex: "flag" or "spawn")
        * @param shard
        */
-      genUniqueObjectName: (type: string, shard = DEFAULT_SHARD): Promise<Api.GameGenUniqueNameResponse> => {
+      genUniqueObjectName: (type: string, shard?: string): Promise<Api.GameGenUniqueNameResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/gen-unique-object-name', { type, shard })
       },
 
       /** POST /api/game/check-unique-object-name */
-      checkUniqueObjectName: (type: string, name: string, shard = DEFAULT_SHARD): Promise<Api.UnknownResponse> => {
+      checkUniqueObjectName: (type: string, name: string, shard?: string): Promise<Api.UnknownResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/check-unique-object-name', { type, name, shard })
       },
 
       /** POST /api/game/place-spawn */
-      placeSpawn: (room: string, x: number, y: number, name: string, shard: string | null = DEFAULT_SHARD): Promise<Api.UnknownResponse> => {
+      placeSpawn: (room: string, x: number, y: number, name: string, shard?: string): Promise<Api.UnknownResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/place-spawn', { name, room, x, y, shard })
       },
 
@@ -152,27 +165,47 @@ export class RawAPI extends EventEmitter {
        *
        * POST /api/game/create-flag
        */
-      createFlag: (room: string, x: number, y: number, name: string, color: FlagColor = 1, secondaryColor: FlagColor = 1, shard = DEFAULT_SHARD): Promise<Api.DbUpsertedResponse> => {
+      createFlag: (room: string, x: number, y: number, name: string, color: FlagColor = 1, secondaryColor: FlagColor = 1, shard?: string): Promise<Api.DbUpsertedResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/create-flag', { name, room, x, y, color, secondaryColor, shard })
       },
 
       /** POST/api/game/gen-unique-flag-name */
-      genUniqueFlagName: (shard = DEFAULT_SHARD): Promise<Api.GameGenUniqueNameResponse> => {
+      genUniqueFlagName: (shard?: string): Promise<Api.GameGenUniqueNameResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/gen-unique-flag-name', { shard })
       },
 
       /** POST /api/game/check-unique-flag-name */
-      checkUniqueFlagName: (name: string, shard = DEFAULT_SHARD): Promise<Api.UnknownResponse> => {
+      checkUniqueFlagName: (name: string, shard?: string): Promise<Api.UnknownResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/check-unique-flag-name', { name, shard })
       },
 
       /** POST /api/game/change-flag-color */
-      changeFlagColor: (color: FlagColor = 1, secondaryColor: FlagColor = 1, shard = DEFAULT_SHARD): Promise<Api.DbModifiedResponse> => {
+      changeFlagColor: (color: FlagColor = 1, secondaryColor: FlagColor = 1, shard?: string): Promise<Api.DbModifiedResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/change-flag-color', { color, secondaryColor, shard })
       },
 
       /** POST /api/game/remove-flag */
-      removeFlag: (room: string, name: string, shard = DEFAULT_SHARD): Promise<Api.Response> => {
+      removeFlag: (room: string, name: string, shard?: string): Promise<Api.Response> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/remove-flag', { name, room, shard })
       },
 
@@ -194,7 +227,11 @@ can destroy multiple structures at once
 intent can be an empty object for suicide and unclaim, but the web interface sends the id in it, as described
         * @example remove construction site: name = "remove", intent = {}
         */
-      addObjectIntent: (_id: string, room: string, name: string, intent?: string, shard = DEFAULT_SHARD): Promise<Api.DbUpsertedResponse> => {
+      addObjectIntent: (_id: string, room: string, name: string, intent?: string, shard?: string): Promise<Api.DbUpsertedResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/add-object-intent', { _id, room, name, intent, shard })
       },
 
@@ -202,7 +239,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
        * POST /api/game/create-construction
        * @param structureType the same value as one of the in-game STRUCTURE_* constants ('road', 'spawn', etc.)
        */
-      createConstruction: (room: string, x: number, y: number, structureType: Api.BuildableStructureConstant, name: string, shard = DEFAULT_SHARD): Promise<Api.GameCreateConstructionResponse> => {
+      createConstruction: (room: string, x: number, y: number, structureType: Api.BuildableStructureConstant, name: string, shard?: string): Promise<Api.GameCreateConstructionResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/create-construction', { room, x, y, structureType, name, shard })
       },
 
@@ -210,37 +251,65 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
        * POST /api/game/set-notify-when-attacked
        * @param enabled is either true or false (literal values, not strings)
        */
-      setNotifyWhenAttacked: (_id: string, enabled = true, shard = DEFAULT_SHARD): Promise<Api.DbModifiedResponse> => {
+      setNotifyWhenAttacked: (_id: string, enabled = true, shard?: string): Promise<Api.DbModifiedResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/set-notify-when-attacked', { _id, enabled, shard })
       },
 
       /** POST /api/game/create-invader */
-      createInvader: (room: string, x: number, y: number, size: 'Melee' | 'Ranged' | 'Healer', type: 'small' | 'big', boosted = false, shard = DEFAULT_SHARD): Promise<Api.UnknownResponse> => {
+      createInvader: (room: string, x: number, y: number, size: 'Melee' | 'Ranged' | 'Healer', type: 'small' | 'big', boosted = false, shard?: string): Promise<Api.UnknownResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/create-invader', { room, x, y, size, type, boosted, shard })
       },
 
       /** POST /api/game/remove-invader */
-      removeInvader: (_id: string, shard = DEFAULT_SHARD): Promise<Api.UnknownResponse> => {
+      removeInvader: (_id: string, shard?: string): Promise<Api.UnknownResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/game/remove-invader', { _id, shard })
       },
 
       /** GET /api/game/time */
-      time: (shard = DEFAULT_SHARD): Promise<Api.GameTimeResponse> => {
+      time: (shard?: string): Promise<Api.GameTimeResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('GET', '/api/game/time', { shard })
       },
 
       /** GET /api/game/world-size */
-      worldSize: (shard = DEFAULT_SHARD): Promise<Api.GameWorldSizeResponse> => {
+      worldSize: (shard?: string): Promise<Api.GameWorldSizeResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('GET', '/api/game/world-size', { shard })
       },
 
       /** GET /api/game/room-decorations */
-      roomDecorations: (room: string, shard = DEFAULT_SHARD): Promise<Api.GameRoomDecorationsResponse> => {
+      roomDecorations: (room: string, shard?: string): Promise<Api.GameRoomDecorationsResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('GET', '/api/game/room-decorations', { room, shard })
       },
 
       /** GET /api/game/room-objects */
-      roomObjects: (room: string, shard = DEFAULT_SHARD): Promise<Api.GameRoomObjectsResponse> => {
+      roomObjects: (room: string, shard?: string): Promise<Api.GameRoomObjectsResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('GET', '/api/game/room-objects', { room, shard })
       },
 
@@ -248,7 +317,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
        * GET /api/game/room-terrain
        * Returns results in "encoded" form (see return type documentation)
        */
-      roomTerrain: (room: string, shard = DEFAULT_SHARD): Promise<Api.GameRoomTerrainEncodedResponse> => {
+      roomTerrain: (room: string, shard?: string): Promise<Api.GameRoomTerrainEncodedResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('GET', '/api/game/room-terrain', { room, encoded: 1, shard })
       },
 
@@ -256,12 +329,20 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
        * GET /api/game/room-terrain
        * Returns results in "unencoded" form (see return type documentation)
        */
-      roomTerrainUnencoded: (room: string, shard = DEFAULT_SHARD): Promise<Api.GameRoomTerrainUnencodedResponse> => {
+      roomTerrainUnencoded: (room: string, shard?: string): Promise<Api.GameRoomTerrainUnencodedResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('GET', '/api/game/room-terrain', { room, shard })
       },
 
       /** GET /api/game/room-status */
-      roomStatus: (room: string, shard = DEFAULT_SHARD): Promise<Api.GameRoomStatusResponse> => {
+      roomStatus: (room: string, shard?: string): Promise<Api.GameRoomStatusResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('GET', '/api/game/room-status', { room, shard })
       },
 
@@ -275,7 +356,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
        * - 180: 3 hours each; 24 hours total
        * - 1440: 24 hours each; 8 days total
        */
-      roomOverview: (room: string, interval: Api.RoomStatInterval = 8, shard = DEFAULT_SHARD): Promise<Api.GameRoomOverviewResponse> => {
+      roomOverview: (room: string, interval: Api.RoomStatInterval = 8, shard?: string): Promise<Api.GameRoomOverviewResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('GET', '/api/game/room-overview', { room, interval, shard })
       },
 
@@ -286,7 +371,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
          *
          * GET /api/game/market/orders-index
          */
-        ordersIndex: (shard = DEFAULT_SHARD): Promise<Api.GameMarketIndexResponse> => {
+        ordersIndex: (shard?: string): Promise<Api.GameMarketIndexResponse> => {
+          shard ??= this.config.client.defaultShard
+          if (shard === undefined) {
+            throw new Error('shard must be defined')
+          }
           return this.req('GET', '/api/game/market/orders-index', { shard })
         },
 
@@ -297,14 +386,19 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
 
         /**
          * GET /api/game/market/orders
-         * @param shard if {@link resourceType} is an {@link IntershardResourceConstant}, this must be set to `undefined`
+         * @param shard if {@link resourceType} is an {@link IntershardResourceConstant}, this must be set to `undefined`.
+         *  {@link Api.ClientConfig.defaultShard} is ignored here for compatibility with intershard resources.
          */
-        orders: (resourceType: Api.MarketResourceConstant, shard = DEFAULT_SHARD): Promise<Api.GameMarketOrdersResponse> => {
+        orders: (resourceType: Api.MarketResourceConstant, shard?: string): Promise<Api.GameMarketOrdersResponse> => {
           return this.req('GET', '/api/game/market/orders', { resourceType, shard })
         },
 
         /** GET /api/game/market/stats */
-        stats: (resourceType: Api.MarketResourceConstant, shard = DEFAULT_SHARD): Promise<Api.GameMarketStatsResponse> => {
+        stats: (resourceType: Api.MarketResourceConstant, shard?: string): Promise<Api.GameMarketStatsResponse> => {
+          shard ??= this.config.client.defaultShard
+          if (shard === undefined) {
+            throw new Error('shard must be defined')
+          }
           return this.req('GET', '/api/game/market/stats', { resourceType, shard })
         }
       },
@@ -525,7 +619,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
          * @param path the portion of the Memory JSON object to retrieve (ex: 'flags.Flag1');
          *  if undefined/empty, returns the entire Memory object
          */
-        get: (path?: string, shard = DEFAULT_SHARD): Promise<Api.UserMemoryGetResponse> => {
+        get: (path?: string, shard?: string): Promise<Api.UserMemoryGetResponse> => {
+          shard ??= this.config.client.defaultShard
+          if (shard === undefined) {
+            throw new Error('shard must be defined')
+          }
           return this.req('GET', '/api/user/memory', { path, shard })
         },
 
@@ -535,7 +633,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
          *  if undefined/empty, returns the entire Memory object
          * @param shard
          */
-        set: (path: string | undefined, value: unknown, shard = DEFAULT_SHARD): Promise<Api.UserMemorySetResponse> => {
+        set: (path: string | undefined, value: unknown, shard?: string): Promise<Api.UserMemorySetResponse> => {
+          shard ??= this.config.client.defaultShard
+          if (shard === undefined) {
+            throw new Error('shard must be defined')
+          }
           return this.req('POST', '/api/user/memory', { path, value, shard })
         },
 
@@ -544,7 +646,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
            * GET /api/user/memory-segment
            * @param segment A number from 0-99
            */
-          get: (segment: number | string, shard = DEFAULT_SHARD): Promise<Api.UserMemorySegmentGetResponse> => {
+          get: (segment: number | string, shard?: string): Promise<Api.UserMemorySegmentGetResponse> => {
+            shard ??= this.config.client.defaultShard
+            if (shard === undefined) {
+              throw new Error('shard must be defined')
+            }
             return this.req('GET', '/api/user/memory-segment', { segment, shard })
           },
 
@@ -552,7 +658,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
            * POST /api/user/memory-segment
            * @param segment A number from 0-99
            */
-          set: (segment: number | string, data: unknown, shard = DEFAULT_SHARD): Promise<Api.UnknownResponse> => {
+          set: (segment: number | string, data: unknown, shard?: string): Promise<Api.UnknownResponse> => {
+            shard ??= this.config.client.defaultShard
+            if (shard === undefined) {
+              throw new Error('shard must be defined')
+            }
             return this.req('POST', '/api/user/memory-segment', { segment, data, shard })
           }
         }
@@ -642,7 +752,11 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
       },
 
       /** POST /api/user/console */
-      console: (expression: string, shard = DEFAULT_SHARD): Promise<Api.UserConsoleResponse> => {
+      console: (expression: string, shard?: string): Promise<Api.UserConsoleResponse> => {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         return this.req('POST', '/api/user/console', { expression, shard })
       },
 
@@ -690,14 +804,16 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
     }
   }
 
-  opts: Api.ServerConfig = {}
+  config: Api.Config
   token?: string
-  protected http?: AxiosInstance
+  protected http: AxiosInstance
   private __authed = false
 
-  constructor(opts?: Api.ServerConfig) {
+  constructor(config: Api.Config) {
     super()
-    this.setServer(opts ?? {})
+    this.config = config
+    this.token = this.config.server.token
+    this.http = axios.create({ baseURL: this.config.server.url })
   }
 
   /**
@@ -716,17 +832,17 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
    * or seasonal world servers
    */
   isOfficialServer(): boolean {
-    return !!this.opts?.url?.match(/screeps\.com/)
+    return !!(/screeps\.com/.exec(this.config.server.url))
   }
 
   /** True if this client is configured for the seasonal world server */
   isSeasonServer(): boolean {
-    return !!this.opts?.url?.match(/screeps\.com\/season/)
+    return !!(/screeps\.com\/season/.exec(this.config.server.url))
   }
 
   /** True if this client is configured for the public test realm (PTR) server */
   isPtrServer(): boolean {
-    return !!this.opts?.url?.match(/screeps\.com\/ptr/)
+    return !!(/screeps\.com\/ptr/.exec(this.config.server.url))
   }
 
   protected mapToShard <R extends Response>(this: void, res: R & { shards?: unknown, list?: unknown, rooms?: unknown }): R {
@@ -736,32 +852,21 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
     return res
   }
 
-  setServer(opts?: Api.ServerConfig) {
-    Object.assign(this.opts, opts ?? {})
-    if (this.opts.path && !this.opts.pathname) {
-      this.opts.pathname = this.opts.path
-    }
-    if (!this.opts.url) {
-      this.opts.url = format(this.opts)
-      if (!this.opts.url.endsWith('/')) this.opts.url += '/'
-    }
-    if (this.opts.token) {
-      this.token = this.opts.token
-    }
-    this.http = axios.create({
-      baseURL: this.opts.url
-    })
-  }
+  /**
+   * Authenticate to the server using the email and password in
+   * `this.config.server`.
+   */
+  async auth(cause?: unknown) {
+    // Skip if already authenticating via API token
+    const server = this.config.server
+    if (server.token) return
 
-  async auth(email: string, password: string, opts?: Api.ServerConfig) {
-    this.setServer(opts)
-    if (email && password) {
-      Object.assign(this.opts, { email, password })
+    if (!server.email || !server.password) {
+      throw new Error('Email or password not provided', { cause })
     }
-    if (!this.opts?.email || !this.opts?.password) {
-      throw new Error('email or password not provided')
-    }
-    const res = await this.raw.auth.signin(this.opts.email, this.opts.password)
+
+    const res = await this.raw.auth.signin(server.email, server.password)
+    this.token = res.token
     this.emit('token', res.token)
     this.emit('auth')
     this.__authed = true
@@ -770,9 +875,6 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async req(method: Api.HttpMethod, path: string, body = {}): Promise<any> {
-    if (!this.http) {
-      throw new Error('http client not configured')
-    }
     const req: AxiosRequestConfig = {
       method,
       url: path,
@@ -811,15 +913,16 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
       this.emit('rateLimit', rateLimit)
       debugRateLimit(`${method} ${path} ${rateLimit.remaining}/${rateLimit.limit} ${rateLimit.toReset}s`)
       if (res.status === 401) {
-        if (this.__authed && this.opts.email && this.opts.password) {
+        const { email, password } = this.config.server
+        if (this.__authed && email && password) {
           this.__authed = false
-          await this.auth(this.opts.email, this.opts.password)
+          await this.auth(err)
           return await this.req(method, path, body)
         } else {
           throw new Error('Not Authorized', { cause: err })
         }
       }
-      if (res.status === 429 && !res.headers['x-ratelimit-limit'] && this.opts.experimentalRetry429) {
+      if (res.status === 429 && !res.headers['x-ratelimit-limit'] && this.config.client.retry429 !== false) {
         await setTimeout(Math.floor(Math.random() * 500) + 200)
         return await this.req(method, path, body)
       }

--- a/src/ScreepsAPI.ts
+++ b/src/ScreepsAPI.ts
@@ -16,65 +16,50 @@ type RateLimits = {
   [method in Api.HttpMethod]: { [path: string]: RateLimit }
 }
 
-const DEFAULTS: Api.ServerConfig = {
-  protocol: 'https',
-  hostname: 'screeps.com',
-  port: 443,
-  path: '/'
-}
-
 const configManager = new ConfigManager()
 
 export class ScreepsAPI extends RawAPI {
-  static async fromConfig(server = 'main', config?: string, opts = {}) {
-    const data = await configManager.getConfig()
+  /**
+   * Search for a config/credential file and initializes the client from the first file found.
+   * If a valid config is loaded and email/password auth is being used, authenticate automatically.
+   * The client can also be initialized by passing a configuration object directly to the constructor.
+   *
+   * @param serverName the property name of the server object to use from the config file
+   * @param opts see {@link Api.LoadConfigOptions}
+   * @throws if the selected config file is invalid or if no config files are found
+   */
+  static async fromConfig(serverName: string, opts?: Api.LoadConfigOptions): Promise<ScreepsAPI> {
+    const config = await configManager.getConfig(serverName, opts)
+    if (!config) throw new Error('No valid config found')
 
-    if (data) {
-      if (!data.servers[server]) {
-        throw new Error(`Server '${server}' does not exist in '${configManager.path}'; valid paths: ${Object.keys(data.servers).join(', ')}`)
-      }
+    const api = new ScreepsAPI(config)
 
-      const conf = data.servers[server]
-      if (conf.ptr) conf.path = '/ptr'
-      if (conf.season) conf.path = '/season'
-      const api = new ScreepsAPI(
-        Object.assign(
-          {
-            hostname: conf.host,
-            port: conf.port,
-            protocol: conf.secure ? 'https' : 'http',
-            token: conf.token,
-            path: conf.path ?? '/'
-          },
-          opts
-        )
-      )
-
-      api.appConfig = data?.configs?.[config!] ?? {}
-
-      if (!conf.token && conf.username && conf.password) {
-        await api.auth(conf.username, conf.password)
-      }
-
-      return api
+    const server = config.server
+    if (!server.token) {
+      await api.auth()
     }
 
-    throw new Error('No valid config found')
+    return api
   }
 
-  appConfig?: Api.AppConfig
   rateLimits: RateLimits
   socket: Socket
 
   private _user?: Api.AuthMeResponse | Api.UserFindResponse['user']
   private _tokenInfo?: Api.TokenInfo
 
-  constructor(opts?: Api.ServerConfig) {
-    opts = Object.assign({}, DEFAULTS, opts)
-    super(opts)
-    this.on('token', (token: string) => {
-      this.token = token
-    })
+  constructor(config: Api.Config)
+  constructor(serverConfig: Api.ServerConfig | Api.RawServerConfig)
+  constructor(config: Api.Config | Api.ServerConfig | Api.RawServerConfig) {
+    if (!('server' in config) || !('client' in config)) {
+      config = {
+        server: new ConfigManager().normalizeServerConfig(config),
+        client: {}
+      }
+    }
+
+    super(config)
+
     const defaultLimit = (limit: number, period: 'minute' | 'hour' | 'day') => ({
       limit,
       period,
@@ -114,6 +99,7 @@ export class ScreepsAPI extends RawAPI {
         toReset: limits.toReset
       })
     })
+
     this.socket = new Socket(this)
   }
 
@@ -142,17 +128,27 @@ export class ScreepsAPI extends RawAPI {
     return this._user
   }
 
+  /**
+   * Fetch permissions and other information about the API token
+   * currently being used by this client
+   */
   async tokenInfo(): Promise<Api.TokenInfo> {
-    if (!this.token) throw new Error('API token not found')
+    if (!this.token) {
+      await this.auth(new Error('Not authenticated; cannot query token info'))
+    }
+
     if (this._tokenInfo) {
       return this._tokenInfo
     }
-    if (this.opts.token) {
-      const { token } = await this.raw.auth.queryToken(this.token)
+
+    if (this.config.server.token) {
+      const { token } = await this.raw.auth.queryToken(this.config.server.token)
       this._tokenInfo = token
     } else {
-      this._tokenInfo = { full: true, token: this.token }
+      // Email/password auth always gets full privileges
+      this._tokenInfo = { full: true, token: this.token! }
     }
+
     return this._tokenInfo
   }
 

--- a/src/Socket.ts
+++ b/src/Socket.ts
@@ -69,10 +69,12 @@ export class Socket extends EventEmitter {
   async connect(opts = {}) {
     Object.assign(this.opts, opts)
     if (!this.api.token) {
-      throw new Error('No token! Call api.auth() before connecting the socket!')
+      await this.api.auth(
+        new Error('No token! Call api.auth() before connecting the socket!')
+      )
     }
     return await new Promise((resolve, reject) => {
-      const baseURL = this.api.opts.url!.replace('http', 'ws')
+      const baseURL = this.api.config.server.url.replace('http', 'ws')
       const wsurl = new URL('socket/websocket', baseURL)
       this.ws = new WebSocket(wsurl)
       this.ws.on('open', () => {


### PR DESCRIPTION
`ConfigManager` is now responsible for normalizing and validating the configuration files it loads, which simplifies the implementations of `RawAPI` and `ScreepsAPI`.

## Breaking Changes
* `experimentalRetry429`
    * Renamed this option to `retry429`
    * It is now specified as a client config option instead of being part of the server config
    * Changed the default to true
* `ScreepsAPI.fromConfig()` parameters have been changed
  * Server name is now required; it no longer defaults to `'main'` to mitigate accidentally defaulting to the user's primary server
  * See docblock for other changes 
* Removed `ScreepsAPI.setServer()` (`RawAPI.setServer()`)
    * Users who need to switch between servers can still do so by using separate instances for each server
* App config from `ScreepsAPI.appConfig` has been moved to `ScreepsAPI.config.client`
* Server config from `ScreepsAPI.config` has been moved to `ScreepsAPI.config.server`
* Endpoints that require a shard argument will now throw an error if one is not defined and if `ScreepsAPI.config.client.defaultShard` is not defined

## Features
* `ScreepsAPI` can now be initialized from `screeps.json` files
* `ScreepsAPI.socket` and `ScreepsAPI.tokenInfo()` will now authenticate automatically if needed
* Added `Api.ClientConfig.defaultShard` to allow a client-wide default
  * `'shard0'` is still used as a default if this option is not set
* Added `Api.VersionResponse.databaseVersion` field (discovered while testing on season 10 server)

## Improvements
It is no longer possible for the Axios client to not be initialized when `RawAPI.req()` is called