### PR TITLE
Fix!: Use correct return type for RawAPI.raw.user.memory.get()

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -618,6 +618,12 @@ declare global {
       2: DbModifiedResult
     }
 
+    /** GET /api/user/memory response */
+    interface UserMemoryGetResponse extends Response {
+      /** Undefined if the specified memory path does not exist */
+      data?: unknown
+    }
+
     /** POST /api/user/memory response */
     interface UserMemorySetResponse extends Response, DbModifiedResponse {
       ops: {

--- a/src/RawAPI.ts
+++ b/src/RawAPI.ts
@@ -524,9 +524,8 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
          * GET /api/user/memory
          * @param path the portion of the Memory JSON object to retrieve (ex: 'flags.Flag1');
          *  if undefined/empty, returns the entire Memory object
-         * @returns the prefix `'gz:'` followed by the base64-encoded gzipped JSON encoding of the requested memory path
          */
-        get: (path?: string, shard = DEFAULT_SHARD): Promise<string> => {
+        get: (path?: string, shard = DEFAULT_SHARD): Promise<Api.UserMemoryGetResponse> => {
           return this.req('GET', '/api/user/memory', { path, shard })
         },
 
@@ -534,8 +533,7 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
          * POST /api/user/memory
          * @param path the portion of the Memory JSON object to write (ex: 'flags.Flag1');
          *  if undefined/empty, returns the entire Memory object
-         * @param {string} shard
-         * @returns {{ ok, result: { ok, n }, ops: [ { user, expression, hidden } ], data, insertedCount, insertedIds }}
+         * @param shard
          */
         set: (path: string | undefined, value: unknown, shard = DEFAULT_SHARD): Promise<Api.UserMemorySetResponse> => {
           return this.req('POST', '/api/user/memory', { path, value, shard })


### PR DESCRIPTION
The return type added by the TypeScript migration was incorrect. This function returns the parsed JSON, not a gzipped string. Also added documentation for the return value when the requested path does not exist.