### PR TITLE
Feat: Expose Debug functionality via RawAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,31 @@ Server endpoints are listed in the `docs` folder:
  * [Endpoints.md](/docs/Endpoints.md) for direct access
  * [Websocket_endpoints.md](/docs/Websocket_endpoints.md) for web socket endpoints
 Those lists are currently not exhaustive.
+
+## Debugging
+
+`node-screeps-api` uses the [Debug](https://www.npmjs.com/package/debug) package to expose diagnostic information. Debug output is divided into several namespaces:
+* `screepsApi:http`: HTTP requests
+* `screepsApi.ratelimit`: HTTP API rate limit state
+* `screepsApi.socket`: Socket API events/messages
+
+Multiple namespaces can be specified by providing a comma-delimited list (ex: `screepsApi:http,screepsApi:ratelimit`). All namespaces can be specified by providing `screepsApi:*`.
+
+To enable debug output in Node, set the `DEBUG` environment variable to the
+namespace(s) you want to enable. Here is an example that uses the CLI in bash:
+```sh
+DEBUG=screepsApi.http,screepsApi.ratelimit screeps-api raw --server main auth.me
+```
+
+These environment variables work when invoking your own apps as well.
+
+You can also enable/disable debug logs dynamically using `ScreepsApi.debug()`:
+```ts
+const api = ScreepsApi.fromConfig('main', 'appName')
+
+// Enable debug logging for HTTP requests and rate limits:
+api.debug({ http: true, rateLimit: true })
+
+// Diable all debug logging
+api.debug()
+```

--- a/src/RawAPI.ts
+++ b/src/RawAPI.ts
@@ -871,6 +871,25 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
       toReset: reset - Math.floor(Date.now() / 1000)
     }
   }
+
+  /**
+   * Enable or disable debug logging.
+   * @param opts if undefined, disables debug logs for all namespaces.
+   *  Otherwise, enables the specified namespaces and disables all others.
+   * @see {@link Api.DebugOptions}
+   */
+  debug(opts?: Api.DebugOptions): void {
+    if (!opts) {
+      Debug.enable('')
+      return
+    }
+
+    const namespaces = Object.entries(opts)
+      .filter((entry: [string, unknown]) => !!entry[1])
+      .map((entry: [string, unknown]) => `screepsapi:${entry[0]}`)
+      .join()
+    Debug.enable(namespaces)
+  }
 }
 
 type RateLimitResponse = AxiosResponse<unknown, unknown, {
@@ -878,3 +897,17 @@ type RateLimitResponse = AxiosResponse<unknown, unknown, {
   'x-ratelimit-remaining': number
   'x-ratelimit-reset': number
 }>
+
+declare global {
+  namespace Api {
+    /** Options to use with {@link ScreepsAPI.debug} */
+    interface DebugOptions {
+      /** Enable debug logs for HTTP API requests */
+      http?: boolean
+      /** Enable debug logs for HTTP API rate limit state */
+      ratelimit?: boolean
+      /** Enable debug logs for WebSocket API events and messages */
+      socket?: boolean
+    }
+  }
+}


### PR DESCRIPTION
This change adds documentation and features to control `node-screeps-api`'s integration with the `debug` package.
* Added `RawAPI.debug()` and `Api.DebugOptions` to control debug logging
* Added documentation to the README for basic debug log initialization via the `DEBUG` env var
