### PR TITLE
Feat!: Improve CLI error handling and help documentation

### DIFF
--- a/bin/screeps-api.ts
+++ b/bin/screeps-api.ts
@@ -9,32 +9,10 @@ interface CommandOptions {
   server?: string
 }
 
-interface MemoryOptions extends CommandOptions {
-  allowRoot?: boolean
-  file?: string
-  set?: string
-  shard?: string
-}
-
-interface SegmentOptions extends CommandOptions {
-  dir?: string
-  set?: string
-  shard?: string
-}
-
-interface DownloadOptions extends CommandOptions {
-  branch: string
-  dir?: string
-}
-
-interface UploadOptions extends CommandOptions {
-  branch: string
-}
-
 type RawApiFn = (...args: unknown[]) => Promise<unknown>
 
 function init(opts?: CommandOptions): Promise<ScreepsAPI> {
-  return ScreepsAPI.fromConfig(opts?.server)
+  return ScreepsAPI.fromConfig(opts?.server ?? 'main')
 }
 
 function json(data: unknown) {
@@ -51,178 +29,217 @@ async function out(data: unknown) {
   }
 }
 
-async function run() {
-  const program = new Command()
+const program = new Command()
 
-  /** @param {string} name */
-  const commandBase = (name: string, args = '') => {
-    const command = new Command(name)
-    command
-      .arguments(args)
-      .option('--server <server>', 'Server config to use', 'main')
-    program.addCommand(command)
-    return command
-  }
-
-  const pkgUrl = new URL('../package.json', import.meta.url)
-  const pkg = JSON.parse(await readFile(pkgUrl, 'utf8')) as { version: string }
-
-  program
-    .version(pkg.version)
-
-  commandBase('raw', '<cmd> [args...]')
-    .description('Execute raw API call')
-    .action(async function (cmd: string, args: unknown[], opts?: CommandOptions) {
-      try {
-        const api = await init(opts)
-        const path = cmd.split('.')
-        let fn: { [key: string]: unknown } | RawApiFn = api.raw
-        for (const part of path) {
-          if (typeof fn === 'function') {
-            console.log('Invalid cmd')
-            return
-          }
-          fn = fn[part] as typeof fn
-        }
-        if (!fn || typeof fn !== 'function') {
-          console.log('Invalid cmd')
-          return
-        }
-        await out(await (fn as RawApiFn).apply(api, args))
-      } catch (e) {
-        console.error(e)
-      }
-    })
-
-  commandBase('memory', '[path]')
-    .description(`Get Memory contents`)
-    .option('--set <file>', 'Sets the memory path to the contents of file')
-    .option('--allow-root', 'Allows writing without path')
-    .option('-s --shard <shard>', 'Shard to read from')
-    .option('-f --file <file>', 'File to write data to')
-    .action(async function (fpath: string, opts: MemoryOptions) {
-      try {
-        const api = await init(opts)
-        if (opts.set) {
-          if (!fpath && !opts.allowRoot) {
-            throw new Error('Refusing to write to root! Use --allow-root if you really want this.')
-          }
-          const data = await readFile(opts.set, 'utf8')
-          await api.memory.set(fpath, data, opts.shard)
-          await out('Memory written')
-        } else {
-          const data = await api.memory.get(fpath, opts.shard)
-          if (opts.file) {
-            await writeFile(opts.file, data)
-          } else {
-            await out(data)
-          }
-        }
-      } catch (e) {
-        console.error(e)
-      }
-    })
-
-  commandBase('segment', '<segment>')
-    .description(`Get segment contents. Use 'all' to get all)`)
-    .option('--set <file>', 'Sets the segment content to the contents of file')
-    .option('-s --shard <shard>', 'Shard to read from')
-    .option('-d --dir <dir>', 'Directory to save in. Empty files are not written. (defaults to outputing in console)')
-    .action(async function (segment: number | string, opts: SegmentOptions) {
-      try {
-        const api = await init(opts)
-        if (opts.set) {
-          if (segment === 'all') {
-            await out('Cannot set all segments at once')
-            return
-          }
-          const data = await readFile(opts.set, 'utf8')
-          await api.memory.segment.set(segment, data, opts.shard)
-          await out('Segment Set')
-        } else {
-          if (segment === 'all') {
-            segment = Array.from({ length: 100 }, (_v, k) => k).join(',')
-          }
-          const { data } = await api.memory.segment.get(segment, opts.shard)
-          const dir = opts.dir
-          const segments = data
-          if (dir) {
-            if (Array.isArray(segments)) {
-              await Promise.all(segments.map(async (d: string, i: number) => {
-                return d && await writeFile(path.join(dir, `segment_${i}`), d)
-              }))
-            } else {
-              await writeFile(path.join(dir, `segment_${segment}`), segments)
-            }
-            await out('Segments Saved')
-          } else {
-            await out(segments)
-          }
-        }
-      } catch (e) {
-        console.error(e)
-      }
-    })
-
-  commandBase('download')
-    .description(`Download code`)
-    .option('-b --branch <branch>', 'Code branch', 'default')
-    .option('-d --dir <dir>', 'Directory to save in (defaults to outputing in console)')
-    .action(async function (opts: DownloadOptions) {
-      try {
-        const api = await init(opts)
-        const dir = opts.dir
-        const { modules } = await api.code.get(opts.branch)
-        if (dir) {
-          await Promise.all(Object.keys(modules).map(async (fn) => {
-            const data = modules[fn]
-            if (typeof data === 'object') {
-              await writeFile(path.join(dir, `${fn}.wasm`), Buffer.from(data.binary, 'base64'))
-            } else {
-              await writeFile(path.join(dir, `${fn}.js`), data)
-            }
-            console.log(`Saved ${fn}`)
-          }))
-        } else {
-          await out(modules)
-        }
-      } catch (e) {
-        console.error(e)
-      }
-    })
-
-  commandBase('upload', '<files...>')
-    .description(`Upload code`)
-    .option('-b --branch <branch>', 'Code branch', 'default')
-    .action(async function (files: string[], opts: UploadOptions) {
-      try {
-        const api = await init(opts)
-        const modules: Api.UserCodeSetRequest['modules'] = {}
-        const ps = []
-        for (const file of files) {
-          ps.push((async (file) => {
-            const { name, ext } = path.parse(file)
-            const data = await readFile(file)
-            if (ext === '.js') {
-              modules[name] = data.toString('utf8')
-            }
-            if (ext === '.wasm') {
-              modules[name] = { binary: data.toString('base64') }
-            }
-          })(file))
-        }
-        await Promise.all(ps)
-        await out(api.code.set({ branch: opts.branch, modules }))
-      } catch (e) {
-        console.error(e)
-      }
-    })
-
-  if (!process.argv.slice(2).length) {
-    program.outputHelp()
-  }
-
-  await program.parseAsync()
+const commandBase = (name: string, args = '') => {
+  const command = new Command(name)
+  command
+    .arguments(args)
+    .option('--server <server>', 'Server config to use', 'main')
+  program.addCommand(command)
+  return command
 }
 
-run().catch(console.error)
+const pkgUrl = new URL('../package.json', import.meta.url)
+const pkg = JSON.parse(await readFile(pkgUrl, 'utf8')) as { version: string }
+
+program
+  .version(pkg.version)
+
+commandBase('raw', '<cmd> [args...]')
+  .summary('Call an API endpoint via ScreepsAPI.raw.<cmd>')
+  .description(`Call an API endpoint defined on ScreepsAPI.raw.
+
+<cmd> is formatted as it would be if you were calling the endpoint via ScreepsAPI.raw.
+[args...] are passed directly to the relevant ScreepsAPI.raw function.
+  `)
+  .addHelpText('after', `Examples:
+# Run 'GET /api/auth/me' on the 'ptr' server from your credentials file
+screeps-api --server ptr raw auth.me
+# Run 'GET /api/scoreboards/list?limit=20&offset=50' on default server
+screeps-api raw scoreboard 20 50
+# Run 'GET /api/scoreboards/list?limit=20&offset=50' on default server
+screeps-api raw scoreboard 20 50
+# Fetch entire Memory object from shard0 on 'mmo' server from your credentials file
+screeps-api raw user.memory.get "" "shard0"
+  `)
+  .action(async function (cmd: string, args: unknown[], opts?: CommandOptions) {
+    const api = await init(opts)
+    const path = cmd.split('.')
+    let fn: { [key: string]: unknown } | RawApiFn = api.raw
+    for (const part of path) {
+      if (typeof fn === 'function') {
+        console.error(`Command '${cmd}' not found on ScreepsAPI.raw`)
+        this.help({ error: true }) // prints to stderr and exits with error code
+      }
+      fn = fn[part] as typeof fn
+    }
+    if (!fn || typeof fn !== 'function') {
+      console.error(`Command '${cmd}' not found on ScreepsAPI.raw`)
+      this.help({ error: true }) // prints to stderr and exits with error code
+    }
+    await out(await (fn as RawApiFn).apply(api, args))
+  })
+
+interface MemoryOptions extends CommandOptions {
+  allowRoot?: boolean
+  file?: string
+  set?: string
+  shard?: string
+  pretty: boolean
+}
+
+commandBase('memory', '[path]')
+  .summary(`Read from or write to Memory`)
+  .description(`Get Memory contents at [path] and emit either emit them to stdout or save them to a file. If Memory at [path] is undefined, no output is emitted.
+
+If --set <file> is used, this command will instead set the value of [path] to the contents of the specified file.
+
+[path] is a dot-delimited sequence of Memory keys. For example, "creeps.myCreep" would be equivalent to calling "Memory.creeps.myCreep" from a bot.
+  `)
+  .option('--set <file>', 'Sets the memory path to the contents of file')
+  .option('--allow-root', 'Allows writing without path')
+  .option('-s --shard <shard>', 'Shard to read from')
+  .option('-f --file <file>', 'File to write data to')
+  .option('-p --pretty', 'Pretty print JSON output')
+  .action(async function (memPath: string, opts: MemoryOptions) {
+    const api = await init(opts)
+
+    if (opts.set) {
+      if (!memPath && !opts.allowRoot) {
+        console.error('Refusing to write to root! Use --allow-root if you really want this.')
+        this.help({ error: true }) // prints to stderr and exits with error code
+      }
+      const data = await readFile(opts.set, 'utf8')
+      await api.memory.set(memPath, data, opts.shard)
+      await out('Memory written')
+      return
+    }
+
+    const res = await api.memory.get(memPath, opts.shard)
+    if (!res.data) {
+      return
+    }
+    const data = opts.pretty
+      ? JSON.stringify(res.data, undefined, 2)
+      : JSON.stringify(res.data)
+    if (opts.file) {
+      await writeFile(opts.file, data)
+    } else {
+      await out(data)
+    }
+  })
+
+interface SegmentOptions extends CommandOptions {
+  dir?: string
+  set?: string
+  shard?: string
+}
+
+commandBase('segment', '<segment>')
+  .description(`Get segment contents. Use 'all' to get all)`)
+  .option('--set <file>', 'Sets the segment content to the contents of file')
+  .option('-s --shard <shard>', 'Shard to read from')
+  .option('-d --dir <dir>', 'Directory to save in. Empty files are not written. (defaults to outputing in console)')
+  .action(async function (segment: number | string, opts: SegmentOptions) {
+    const api = await init(opts)
+    if (opts.set) {
+      if (segment === 'all') {
+        console.error('Cannot set all segments at once')
+        this.help({ error: true }) // prints to stderr and exits with error code
+      }
+      const data = await readFile(opts.set, 'utf8')
+      await api.memory.segment.set(segment, data, opts.shard)
+      await out('Segment Set')
+    } else {
+      if (segment === 'all') {
+        segment = Array.from({ length: 100 }, (_v, k) => k).join(',')
+      }
+      const { data } = await api.memory.segment.get(segment, opts.shard)
+      const dir = opts.dir
+      const segments = data
+      if (dir) {
+        if (Array.isArray(segments)) {
+          await Promise.all(segments.map(async (d: string, i: number) => {
+            return d && await writeFile(path.join(dir, `segment_${i}`), d)
+          }))
+        } else {
+          await writeFile(path.join(dir, `segment_${segment}`), segments)
+        }
+        await out('Segments Saved')
+      } else {
+        await out(segments)
+      }
+    }
+  })
+
+interface DownloadOptions extends CommandOptions {
+  branch: string
+  dir?: string
+}
+
+commandBase('download')
+  .description(`Download code and WASM binaries`)
+  .option('-b --branch <branch>', 'Code branch', 'default')
+  .option('-d --dir <dir>', 'Directory to save in (emits to stdout by default)')
+  .action(async function (opts: DownloadOptions) {
+    const api = await init(opts)
+    const dir = opts.dir
+    const { modules } = await api.code.get(opts.branch)
+    if (dir) {
+      await Promise.all(Object.keys(modules).map(async (fn) => {
+        const data = modules[fn]
+        if (typeof data === 'object') {
+          await writeFile(path.join(dir, `${fn}.wasm`), Buffer.from(data.binary, 'base64'))
+        } else {
+          await writeFile(path.join(dir, `${fn}.js`), data)
+        }
+        console.log(`Saved ${fn}`)
+      }))
+    } else {
+      await out(modules)
+    }
+  })
+
+interface UploadOptions extends CommandOptions {
+  branch: string
+}
+
+commandBase('upload', '<files...>')
+  .description(`Upload code and WASM binaries`)
+  .option('-b --branch <branch>', 'Code branch', 'default')
+  .action(async function (files: string[], opts: UploadOptions) {
+    const api = await init(opts)
+    const modules: Api.UserCodeSetRequest['modules'] = {}
+    const ps = []
+    for (const file of files) {
+      ps.push((async (file) => {
+        const { name, ext } = path.parse(file)
+        const data = await readFile(file)
+        if (ext === '.js') {
+          modules[name] = data.toString('utf8')
+        }
+        if (ext === '.wasm') {
+          modules[name] = { binary: data.toString('base64') }
+        }
+      })(file))
+    }
+    await Promise.all(ps)
+    await out(api.code.set({ branch: opts.branch, modules }))
+  })
+
+function run() {
+  if (!process.argv.slice(2).length) {
+    program.outputHelp()
+    process.exit(1)
+  }
+
+  try {
+    program.parse()
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}
+
+run()


### PR DESCRIPTION
Breaking Changes:
* Changed error-handling behavior:
  * Help is now printed after usage errors (ex: invalid raw command)
  * Non-zero exit status is now returned on all errors
* Changed `memory` output format:
  * Nothing is emitted if the Memory path does not exist
  * JSON output is stringified before being emitted to stdout to allow the full contents to be inspected

Improvements:
* Added detailed help description and examples to `raw` command
* Added detailed help description to `memory` command
* Added `memory --pretty` option to pretty-print output to files or stdout