### PR TITLE
Feat!: Add retry with exponential backoff for endpoint rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Those lists are currently not exhaustive.
 `node-screeps-api` uses the [Debug](https://www.npmjs.com/package/debug) package to expose diagnostic information. Debug output is divided into several namespaces:
 * `screepsApi:http`: HTTP requests
 * `screepsApi.ratelimit`: HTTP API rate limit state
+* `screepsApi.ratelimitexceeded`: HTTP API endpoint rate limit exceeded events
 * `screepsApi.socket`: Socket API events/messages
 
 Multiple namespaces can be specified by providing a comma-delimited list (ex: `screepsApi:http,screepsApi:ratelimit`). All namespaces can be specified by providing `screepsApi:*`.

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -6,6 +6,12 @@ import { parse } from 'yaml'
 
 const DEFAULT_SERVER_HOST = 'screeps.com'
 const DEFAULT_SERVER_PATH = '/'
+export const DEFAULT_CLIENT_CONFIG: Api.ClientConfig = {
+  retry429Global: true,
+  retry429InitDelay: 60_000,
+  retry429MaxDelay: 10_800_000,
+  retry429MaxRetries: 0
+} as const
 
 export class ConfigManager {
   path?: string
@@ -187,7 +193,7 @@ export class ConfigManager {
     file: string,
     opts?: Api.LoadConfigOptions
   ): Api.ClientConfig {
-    const client: Api.ClientConfig = {}
+    const client: Api.ClientConfig = { ...DEFAULT_CLIENT_CONFIG }
     if (!opts?.client) {
       return client
     }
@@ -246,7 +252,7 @@ declare global {
        * {@link ClientConfig} will be pulled from the `configs[client]` key
        * in that file.
        */
-      client?: string | ClientConfig
+      client?: string | Partial<ClientConfig>
     }
 
     /** Normalized configuration for a single Screeps World server */
@@ -269,10 +275,32 @@ declare global {
        */
       defaultShard?: string
       /**
-       * Automatically retry requests that fail due to rate limiting
+       * Wait for a short period of time before automatically retriing
+       * requests that fail due to the global 120 requests/minute rate limit.
        * @default true
        */
-      retry429?: boolean
+      retry429Global: boolean
+      /**
+       * Delay (in milliseconds) before the first retry attempt.
+       * Only applies to retries for endpoint-specific rate limits.
+       * @default 60000 (one minute)
+       */
+      retry429InitDelay: number
+      /**
+       * Maximum delay (in milliseconds) between retry attempts.
+       * Only applies to retries for endpoint-specific rate limits.
+       * @default 10800000 (three hours)
+       */
+      retry429MaxDelay: number
+      /**
+       * Maximum number of retry attempts. Exponential backoff is used
+       * to increase the delay between subsequent retry attempts.
+       * Only applies to retries for endpoint-specific rate limits.
+       * When this is enabled, `ScreepsAPI.debug('screepsapi:ratelimitexceeded')`
+       * will cause the client to emit logs when delays occur due to retries.
+       * @default 0
+       */
+      retry429MaxRetries: number
     } & { [propertyName: string]: unknown }
 
     /** Server configuration schema from {@link JsonConfig}/{@link YamlConfig} */

--- a/src/RawAPI.ts
+++ b/src/RawAPI.ts
@@ -9,6 +9,7 @@ import { FlagColor } from './Api'
 
 const debugHttp = Debug('screepsapi:http')
 const debugRateLimit = Debug('screepsapi:ratelimit')
+const debugRateLimitExceeded = Debug('screepsapi:ratelimitexceeded')
 
 const gunzipAsync = utils.promisify(zlib.gunzip)
 const inflateAsync = utils.promisify(zlib.inflate)
@@ -873,34 +874,45 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
     return res
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async req(method: Api.HttpMethod, path: string, body = {}): Promise<any> {
+  async req(
+    method: Api.HttpMethod,
+    path: string,
+    body = {},
+    retriesAttempted = 0
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any> {
+    debugHttp(`${method} ${path} ${JSON.stringify(body)}`)
+
     const req: AxiosRequestConfig = {
       method,
       url: path,
       headers: {}
     }
-    debugHttp(`${method} ${path} ${JSON.stringify(body)}`)
+
     if (this.token) {
       Object.assign((req.headers as object), {
         'X-Token': this.token,
         'X-Username': this.token
       })
     }
+
     if (method === 'GET') {
       req.params = body
     } else {
       req.data = body
     }
+
     try {
       const res = await this.http(req)
       const token = res.headers['x-token'] as string
       if (token) {
         this.emit('token', token)
       }
+
       const rateLimit = this.buildRateLimit(method, path, res as RateLimitResponse)
       this.emit('rateLimit', rateLimit)
       debugRateLimit(`${method} ${path} ${rateLimit.remaining}/${rateLimit.limit} ${rateLimit.toReset}s`)
+
       const data = res.data as { data?: unknown }
       if (typeof data.data === 'string' && data.data.startsWith('gz:')) {
         data.data = await this.gz(data.data)
@@ -909,9 +921,13 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
       return res.data
     } catch (err) {
       const res = ((err as { response?: AxiosResponse }).response ?? {}) as RateLimitResponse
+
       const rateLimit = this.buildRateLimit(method, path, res)
       this.emit('rateLimit', rateLimit)
-      debugRateLimit(`${method} ${path} ${rateLimit.remaining}/${rateLimit.limit} ${rateLimit.toReset}s`)
+      const rateLimitDesc = `${method} ${path} remaining=${rateLimit.remaining}/${rateLimit.limit} reset=${rateLimit.toReset}s`
+      debugRateLimit(rateLimitDesc)
+
+      // Attempt to authenticate in response to "Not Authorized" errors
       if (res.status === 401) {
         const { email, password } = this.config.server
         if (this.__authed && email && password) {
@@ -922,10 +938,32 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
           throw new Error('Not Authorized', { cause: err })
         }
       }
-      if (res.status === 429 && !res.headers['x-ratelimit-limit'] && this.config.client.retry429 !== false) {
-        await setTimeout(Math.floor(Math.random() * 500) + 200)
-        return await this.req(method, path, body)
+
+      // Retry (if enabled) in response to "Too Many Requests" errors
+      if (res.status === 429) {
+        // Global rate limit is indicated by the lack of rate limit headers
+        const isGlobal = !res.headers['x-ratelimit-limit']
+        const cfg = this.config.client
+
+        // Handle global rate limit
+        if (isGlobal && cfg.retry429Global !== false) {
+          const delay = Math.floor(Math.random() * 500) + 200
+          await setTimeout(delay)
+          return await this.req(method, path, body, retriesAttempted + 1)
+        }
+
+        // Handle endpoint-specific rate limits
+        if (!isGlobal && retriesAttempted < cfg.retry429MaxRetries) {
+          const delay = Math.min(
+            cfg.retry429InitDelay * (2 ** retriesAttempted),
+            cfg.retry429MaxDelay
+          )
+          debugRateLimitExceeded(rateLimitDesc + ` retriesAttempted=${retriesAttempted} delay=${delay / 1_000}s`)
+          await setTimeout(delay)
+          return await this.req(method, path, body, retriesAttempted + 1)
+        }
       }
+
       if ((err as { response?: AxiosResponse }).response) {
         const details = {
           params: {},
@@ -934,11 +972,14 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
           status: res.status,
           statusText: res.statusText
         }
+
         if (!path.startsWith('/api/auth')) {
           Object.assign(details.params, res.config?.params as object ?? {})
         }
+
         throw new Error(JSON.stringify(details, undefined, 2), { cause: err })
       }
+
       throw err
     }
   }
@@ -1007,6 +1048,8 @@ declare global {
       http?: boolean
       /** Enable debug logs for HTTP API rate limit state */
       ratelimit?: boolean
+      /** Enable debug logs for HTTP API rate limit exceeded events */
+      ratelimitexceeded?: boolean
       /** Enable debug logs for WebSocket API events and messages */
       socket?: boolean
     }

--- a/src/ScreepsAPI.ts
+++ b/src/ScreepsAPI.ts
@@ -1,4 +1,4 @@
-import { ConfigManager } from './ConfigManager'
+import { ConfigManager, DEFAULT_CLIENT_CONFIG } from './ConfigManager'
 import { RawAPI } from './RawAPI'
 import { Socket } from './Socket'
 
@@ -54,7 +54,7 @@ export class ScreepsAPI extends RawAPI {
     if (!('server' in config) || !('client' in config)) {
       config = {
         server: new ConfigManager().normalizeServerConfig(config),
-        client: {}
+        client: { ...DEFAULT_CLIENT_CONFIG }
       }
     }
 


### PR DESCRIPTION
Adds options for automatic retry with exponential backoff for 429 errors caused by endpoint-specific rate limits.

Breaking Changes:
* Renamed `retry429` to `retry429Global` and added docblock to indicate that this option only controls retries for the global rate limit

Features:
* Added `retry429InitDelay`, `retry429MaxDelay`, and `retry429MaxRetries` to control automatic retries on endpoint rate limit errors
* Added `screepsapi:ratelimitexceeded` debug namespace to log endpoint rate limit retries
