### PR TITLE
Flesh out docblocks

### DIFF
--- a/bin/screeps-api.ts
+++ b/bin/screeps-api.ts
@@ -136,21 +136,27 @@ interface SegmentOptions extends CommandOptions {
   shard?: string
 }
 
-commandBase('segment', '<segment>')
-  .description(`Get segment contents. Use 'all' to get all)`)
+commandBase('segment', '<segments>')
+  .description(`Read or write RawMemory segments.
+
+Reads/downloads segment data by default. <segments> should be a comma-delimited
+list of all segment IDs that should be fetched (or 'all' to get all segments).
+
+If --set <file> is used, <segments> must be the ID of a single segment.
+  `)
   .option('--set <file>', 'Sets the segment content to the contents of file')
   .option('-s --shard <shard>', 'Shard to read from')
   .option('-d --dir <dir>', 'Directory to save in. Empty files are not written. (defaults to outputing in console)')
   .action(async function (segment: number | string, opts: SegmentOptions) {
     const api = await init(opts)
     if (opts.set) {
-      if (segment === 'all') {
-        console.error('Cannot set all segments at once')
+      if (segment === 'all' || segment.toString().includes(',')) {
+        console.error('Cannot set multiple segments at once')
         this.help({ error: true }) // prints to stderr and exits with error code
       }
       const data = await readFile(opts.set, 'utf8')
-      await api.memory.segment.set(segment, data, opts.shard)
-      await out('Segment Set')
+      await api.memory.segment.set(segment, JSON.parse(data), opts.shard)
+      await out('Segment uploaded')
     } else {
       if (segment === 'all') {
         segment = Array.from({ length: 100 }, (_v, k) => k).join(',')
@@ -160,13 +166,16 @@ commandBase('segment', '<segment>')
       const segments = data
       if (dir) {
         if (Array.isArray(segments)) {
-          await Promise.all(segments.map(async (d: string, i: number) => {
+          await Promise.all(segments.map(async (d: string | null, i: number) => {
             return d && await writeFile(path.join(dir, `segment_${i}`), d)
           }))
-        } else {
+          await out(`Segments ${segment} downloaded`)
+        } else if (segments) {
           await writeFile(path.join(dir, `segment_${segment}`), segments)
+          await out(`Segment ${segment} downloaded`)
+        } else {
+          await out(`Segment ${segment} was null`)
         }
-        await out('Segments Saved')
       } else {
         await out(segments)
       }

--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -1,0 +1,22 @@
+---
+title: HTTP API Rate Limits
+group: Guides
+category:
+- HTTP API
+---
+# HTTP API Rate Limits
+
+A global rate limit of 120 requests per minute (2 requests per second) applies
+to requests made to any endpoint. Requests that fail due to this rate limit
+are automatically retried by default. To disable this behavior, set
+`Api.ClientConfig.retry429Global` to false when initializing the client.
+
+Certain endpoints have an additional rate limit. If your requests fail due
+this limit, there are 3 ways to resolve or mitigate the issue:
+1. Rewrite your application to make fewer requests to the limited endpoint
+2. Enable automatic retries by setting `Api.ClientConfig.retry429MaxRetries`
+  to a positive number.
+3. Open `ScreepsAPI.rateLimitResetUrl` periodically to manually reset
+  your rate limits for all endpoints.
+
+See the [official documentation](https://docs.screeps.com/auth-tokens.html#Rate-Limiting) for more details on rate limits.

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -1,33 +1,34 @@
 declare global {
-  /** node-screeps-api types */
+  /** Namespace for all public `node-screeps-api` types */
   namespace Api {
-    /** Body of a API success response */
+    /**
+     * Body of a HTTP API success response.
+     *
+     * All {@link ScreepsAPI.raw} functions will return a valid that
+     * extends this type.
+     * @see {@link Error} if an API error is thrown.
+     */
     interface Response {
       /** An API success response always contains `{ ok: 1 }` */
       ok: 1
     }
 
     /**
-     * Body of an API success response that has not been typed yet.
-     * Please consider submitting a PR to replace this type
-     * if you have a sample response body.
+     * Body of an HTTP API success response that has not been typed yet.
+     * Please consider submitting a PR to replace this with a defined type
+     * if you have a sample response body!
      */
     interface UnknownResponse extends Response {
       [propertyName: string]: unknown
     }
 
     /**
-     * Error details: either a simple error message string (ex: 'invalid'),
-     * or detailed request/response data
+     * Thrown by {@link ScreepsAPI} endpoint functions when an error response
+     * is received from an HTTP API endpoint.
      */
-    interface ErrorResponse {
-      /** The API request that caused the error */
-      config: {
-        headers: { [headerName: string]: unknown }
-        method: HttpMethod
-        params?: { [paramName: string]: unknown }
-        url: string
-      }
+    interface Error extends globalThis.Error {
+      /** Params from the API request which caused the error */
+      params: { [paramName: string]: unknown }
       /**
        * The response body (usually an HTML document
        * with an error message in the body)
@@ -40,7 +41,7 @@ declare global {
       statusText: string
     }
 
-    /** GET /api/version response */
+    /** `GET /api/version` response */
     interface VersionResponse extends Response {
       /** Client version number; undefined on non-official servers */
       package?: number
@@ -86,7 +87,7 @@ declare global {
       users: number
     }
 
-    /** GET /api/authmod response */
+    /** `GET /api/authmod` response */
     type AuthModResponse = OfficialAuthModResponse | UnofficialAuthModResponse
 
     interface OfficialAuthModResponse extends Response {
@@ -104,7 +105,7 @@ declare global {
       version: string
     }
 
-    /** GET /api/room-history response: a room history JSON file */
+    /** `GET /api/room-history` response: a room history JSON file */
     interface RoomHistoryResponse extends Response {
       /** UNIX timestamp (UTC) indicating the time at the start of the chunk */
       timestamp: number
@@ -112,6 +113,7 @@ declare global {
       room: string
       /** Number of the first tick in this chunk */
       base: number
+      /** History data indexed by tick */
       ticks: { [tick: number]: HistoryTick }
     }
 
@@ -120,28 +122,31 @@ declare global {
       [id: string]: RoomObject
     }
 
-    /** POST /api/servers/list response: a curated list of community-run servers */
+    /** `POST /api/servers/list` response: a curated list of community-run servers */
     interface ServerListResponse extends Response {
-      servers: {
-        _id: string
-        settings: {
-          host: string
-          port: string
-          pass: string
-        }
-        name: string
-        /** Usually 'active' */
-        status: string
-        likeCount: number
-      }
+      servers: Server[]
     }
 
-    /** POST /api/auth/signin response */
+    /** A server from {@link ServerListResponse} */
+    interface Server {
+      _id: string
+      settings: {
+        host: string
+        port: string
+        pass: string
+      }
+      name: string
+      /** Usually 'active' */
+      status: string
+      likeCount: number
+    }
+
+    /** `POST /api/auth/signin` response */
     interface AuthSigninResponse extends Response {
       token: string
     }
 
-    /** GET /api/auth/me response */
+    /** `GET /api/auth/me` response */
     interface AuthMeResponse extends Response {
       _id: string
       badge?: Badge
@@ -204,7 +209,7 @@ declare global {
       username: string
     }
 
-    /** GET /api/auth/query-token response */
+    /** `GET /api/auth/query-token` response */
     interface AuthQueryTokenResponse extends Response {
       _id: string
       token: TokenInfo
@@ -226,7 +231,19 @@ declare global {
       description?: string
     }
 
-    /** POST /api/game/map-stats response */
+    /**
+     * Response returned by some endpoints when an issue occurs.
+     * Despite the name and fields of this type, this is returned with
+     * an HTTP 200 status, and {@link ScreepsAPI} does not throw this
+     * as an error.
+     * @see {@link Error} for the Error type thrown when an endpoint returns
+     * an error response with a non-2xx status.
+     */
+    interface ErrorResponse extends Response {
+      error: string
+    }
+
+    /** `POST /api/game/map-stats` response */
     interface GameMapStatsResponse<S extends MapStat> extends Response {
       gameTime: number
       stats: {
@@ -267,14 +284,14 @@ declare global {
     }
 
     /**
-     * POST /api/game/gen-unique-object-name and
-     * POST /api/game/gen-unique-flag-name responses
+     * `POST /api/game/gen-unique-object-name` and
+     * `POST /api/game/gen-unique-flag-name` responses
      */
     interface GameGenUniqueNameResponse extends Response {
       name: string
     }
 
-    /** POST /api/game/create-construction response */
+    /** `POST /api/game/create-construction` response */
     interface GameCreateConstructionResponse extends Response {
       result: {
         ok: 1
@@ -295,12 +312,12 @@ declare global {
       insertedIds: string[]
     }
 
-    /** GET /api/game/time response */
+    /** `GET /api/game/time` response */
     interface GameTimeResponse extends Response {
       time: number
     }
 
-    /** GET /api/game/world-size response */
+    /** `GET /api/game/world-size` response */
     interface GameWorldSizeResponse extends Response {
       /** Width of this shard's map (in rooms) */
       width: number
@@ -308,18 +325,21 @@ declare global {
       height: number
     }
 
-    /** GET /api/game/room-decorations response */
+    /** `GET /api/game/room-decorations` response */
     interface GameRoomDecorationsResponse extends Response {
       decorations: Decorations.Instance[]
     }
 
-    /** GET /api/game/room-objects response */
+    /** `GET /api/game/room-objects` response */
     interface GameRoomObjectsResponse extends Response {
       objects: RoomObject[]
       users: Users
     }
 
-    /** GET /api/game/room-terrain response when `encoded` param is defined and non-empty */
+    /**
+     * `GET /api/game/room-terrain` response when `encoded` param is
+     * defined and non-empty
+     */
     interface GameRoomTerrainEncodedResponse extends Response {
       terrain: {
         0: {
@@ -336,7 +356,10 @@ declare global {
       }
     }
 
-    /** GET /api/game/room-terrain response when `encoded` param is undefined|null|'' */
+    /**
+     * `GET /api/game/room-terrain` response when `encoded` param
+     * is undefined|null|''
+     */
     interface GameRoomTerrainUnencodedResponse extends Response {
       /** Unlisted positions are of type `plain` */
       terrain: {
@@ -347,7 +370,7 @@ declare global {
       }[]
     }
 
-    /** GET /api/game/room-status response */
+    /** `GET /api/game/room-status` response */
     interface GameRoomStatusResponse extends Response {
       /** The room name */
       _id: string
@@ -360,7 +383,7 @@ declare global {
       status: RoomStatus
     }
 
-    /** GET /api/game/room-overview response */
+    /** `GET /api/game/room-overview` response */
     interface GameRoomOverviewResponse extends Response {
       owner: {
         badge: Badge
@@ -385,7 +408,7 @@ declare global {
       totals: { [statId in RoomStat]: number | undefined }
     }
 
-    /** GET /api/game/market/orders-index response */
+    /** `GET /api/game/market/orders-index` response */
     interface GameMarketIndexResponse extends Response {
       list: {
         _id: MarketResourceConstant
@@ -397,23 +420,23 @@ declare global {
     }
 
     /**
-     * GET /api/game/market/my-orders response
-     * Intershard orders will be listed under the `'intershard'` key
+     * `GET /api/game/market/my-orders` response
+     * Intershard orders will be listed under the `intershard` key
      */
     type GameMarketMyOrdersResponse = Response & {
       [shardName: string]: Order[]
     }
 
-    /** GET /api/game/market/orders response */
+    /** `GET /api/game/market/orders` response */
     interface GameMarketOrdersResponse extends Response {
       list: OpenOrder[]
     }
 
-    /** GET /api/game/market/stats resonse */
+    /** `GET /api/game/market/stats` resonse */
     interface GameMarketStatsResponse extends Response {
       stats: {
         _id: string
-        /** YYYY-MM-DD format */
+        /** Date to which this stats entry corresponds in YYYY-MM-DD format */
         date: string
         resourceType: MarketResourceConstant
         avgPrice: number
@@ -423,7 +446,7 @@ declare global {
       }[]
     }
 
-    /** GET /api/game/shards/info response */
+    /** `GET /api/game/shards/info` response */
     interface GameShardsInfoResponse extends Response {
       shards: {
         name: string
@@ -439,7 +462,7 @@ declare global {
       }[]
     }
 
-    /** GET /api/leaderboard/list response */
+    /** `GET /api/leaderboard/list` response */
     interface LeaderboardListResponse extends Response {
       list: LeaderboardResult[]
       /** Total number of results in this season */
@@ -447,9 +470,10 @@ declare global {
       users: Users
     }
 
-    /** GET /api/leaderboard/find response */
+    /** `GET /api/leaderboard/find` response */
     interface LeaderboardFindResponse extends Response, LeaderboardResult {}
 
+    /** A user's leaderboard result for a single season */
     interface LeaderboardResult {
       _id: string
       season: string
@@ -458,7 +482,7 @@ declare global {
       rank: number
     }
 
-    /** GET /api/leaderboard/seasons response */
+    /** `GET /api/leaderboard/seasons` response */
     interface LeaderboardSeasonsResponse extends Response {
       seasons: {
         /** YYYY-MM */
@@ -470,7 +494,15 @@ declare global {
       }[]
     }
 
-    /** GET /api/seasons/current response */
+    /**
+     * The types of leaderboard available via the
+     * {@link ScreepsAPI.raw.leaderboard} endpoints:
+     * - 'world': Control Points (as used to earn Global Control Level)
+     * - 'power': Power Processed (as used to earn Global Power Level)
+     */
+    type LeaderboardType = 'world' | 'power'
+
+    /** `GET /api/seasons/current` response */
     interface SeasonsCurrentResponse extends Response {
       /** Name of the season (ex: "Season 8") */
       title: string
@@ -488,7 +520,7 @@ declare global {
       updatedAt: string
     }
 
-    /** POST /api/user/notify-prefs response */
+    /** `POST /api/user/notify-prefs` response */
     interface UserNotifyPrefsRequest {
       disabled: boolean
       disabledOnMessages?: boolean
@@ -497,7 +529,7 @@ declare global {
       errorsInterval?: number
     }
 
-    /** GET /api/user/world-start-room response */
+    /** `GET /api/user/world-start-room` response */
     interface UserWorldStartRoomResponse extends Response {
       /**
        * Zero or one room names; if a shard name was not included in the request,
@@ -506,7 +538,7 @@ declare global {
       room: string[]
     }
 
-    /** GET /api/user/world-status response */
+    /** `GET /api/user/world-status` response */
     interface UserWorldStatusResponse extends Response {
       /**
        * - Normal: user has one or more active spawns
@@ -517,7 +549,7 @@ declare global {
       status: 'normal' | 'lost' | 'empty'
     }
 
-    /** GET /api/user/branches response */
+    /** `GET /api/user/branches` response */
     interface UserBranchesResponse extends Response {
       list: {
         _id: string
@@ -527,21 +559,37 @@ declare global {
       }[]
     }
 
-    /** GET /api/user/code response */
+    /** `GET /api/user/code` response */
     interface UserCodeGetResponse extends Response, UserCodeSetRequest {}
 
-    /** POST /api/user/code response */
+    /** `POST /api/user/code` response */
     interface UserCodeSetRequest {
+      /**
+       * The name of the branch
+       * @see {@link ScreepsAPI.raw.user.branches} to list available branches
+       */
       branch: string
-      modules: { [moduleName: string]: string | { binary: string } }
+      /** JavaScript code and WASM binaries keyed by module name */
+      modules: UserCodeModules
     }
 
-    /** GET /api/user/decorations/inventory response */
+    /** Describes a collection of code modules */
+    interface UserCodeModules {
+      /**
+       * JavaScript code or WASM binaries keyed by module name.
+       * If the value of a module is a string, it is treated as JavaScript.
+       * If the value of a module is an object with a `binary` property,
+       * the value of that property is treated as a WASM binary.
+       */
+      [moduleName: string]: string | { binary: string }
+    }
+
+    /** `GET /api/user/decorations/inventory` response */
     interface UserDecorationInventoryResponse extends Response {
       list: Decorations.Instance[]
     }
 
-    /** GET /api/user/decorations/themes response */
+    /** `GET /api/user/decorations/themes` response */
     interface UserDecorationThemesResponse extends Response {
       list: {
         _id: string
@@ -557,7 +605,7 @@ declare global {
       }[]
     }
 
-    /** GET /api/user/messages/list response */
+    /** `GET /api/user/messages/list` response */
     interface UserMessagesListResponse extends Response {
       messages: {
         /** ID of the message */
@@ -588,7 +636,7 @@ declare global {
       unread: boolean
     }
 
-    /** GET /api/user/messages/index response */
+    /** `GET /api/user/messages/index` response */
     interface UserMessagesIndexResponse extends Response {
       messages: {
         _id: string
@@ -607,25 +655,25 @@ declare global {
       outMessage: string
     }
 
-    /** GET /api/user/messages/unread-count response */
+    /** `GET /api/user/messages/unread-count` response */
     interface UserMessagesUnreadCountResponse extends Response {
       count: number
     }
 
-    /** POST /api/user/messages/mark-read response */
+    /** `POST /api/user/messages/mark-read` response */
     interface UserMessagesMarkReadResponse extends Response {
       0: number
       1: number
       2: DbModifiedResult
     }
 
-    /** GET /api/user/memory response */
+    /** `GET /api/user/memory` response */
     interface UserMemoryGetResponse extends Response {
       /** Undefined if the specified memory path does not exist */
       data?: unknown
     }
 
-    /** POST /api/user/memory response */
+    /** `POST /api/user/memory` response */
     interface UserMemorySetResponse extends Response, DbModifiedResponse {
       ops: {
         user: string
@@ -637,12 +685,22 @@ declare global {
       insertedIds: string[]
     }
 
-    /** GET /api/user/memory-segment response */
+    /** `GET /api/user/memory-segment` response */
     interface UserMemorySegmentGetResponse extends Response {
-      data: string | string[]
+      /**
+       * The contents of the requested {@link https://docs.screeps.com/api/#RawMemory.segments | RawMemory.segments}.
+       *
+       * If a single segment ID is specified, returns the contents of that segment as a string.
+       *
+       * If multiple segment IDs are specified, returns the contents of each requested segment as a string array.
+       * The order of segment data in this array matches the order of the segment IDs array from the request.
+       *
+       * `null` will be returned instead of a string for any uninitialized segment.
+       */
+      data: string | null | (string | null)[]
     }
 
-    /** GET /api/user/find response */
+    /** `GET /api/user/find` response */
     interface UserFindResponse extends Response {
       user: User & {
         /** Total control points earned by this user */
@@ -656,7 +714,7 @@ declare global {
       }
     }
 
-    /** GET /api/user/respawn-prohibited-rooms response */
+    /** `GET /api/user/respawn-prohibited-rooms` response */
     interface UserRespawnProhibitedRoomsResponse extends Response {
       /**
        * Zero or one room names; results are formatted as `${shardName}/${roomName}`
@@ -664,7 +722,7 @@ declare global {
       rooms: string[]
     }
 
-    /** GET /api/user/rooms response */
+    /** `GET /api/user/rooms` response */
     interface UserRoomsResponse extends Response {
       /** All arrays in this object will always be empty */
       reservations: { [shardName: string]: string[] }
@@ -672,7 +730,15 @@ declare global {
       shards: { [shardName: string]: string[] }
     }
 
-    /** GET /api/user/overview response */
+    /** `GET /api/user/stats` response */
+    interface UserStatsResponse extends Response {
+      stats: {
+        /** The value of each stat over the requested {@link RoomStatInterval} */
+        [statId in RoomStat]: number
+      }
+    }
+
+    /** `GET /api/user/overview` response */
     interface UserOverviewResponse extends Response {
       statsMax: number
       totals: { [statName in RoomStat]: number }
@@ -699,7 +765,7 @@ declare global {
       }
     }
 
-    /** GET /api/user/money-history response */
+    /** `GET /api/user/money-history` response */
     interface UserMoneyHistoryResponse extends Response {
       list: {
         _id: string
@@ -760,7 +826,7 @@ declare global {
       }
     }
 
-    /** POST /api/user/console response */
+    /** `POST /api/user/console` response */
     interface UserConsoleResponse extends Response {
       result: {
         ok: 1
@@ -776,16 +842,17 @@ declare global {
       insertedIds: [string]
     }
 
-    /** GET /api/user/name response */
+    /** `GET /api/user/name` response */
     interface UserNameResponse extends Response {
       username: string
     }
 
-    /** GET /api/experimental/pvp response */
+    /** `GET /api/experimental/pvp` response */
     interface ExperimentalPvpResponse extends Response {
+      /** Rooms with current/recent combat activity grouped by shard name */
       pvp: {
         [shardName: string]: {
-          /** Results sorted by {@link lastPvpTime} DESC */
+          /** Rooms sorted in descending order of {@link lastPvpTime} */
           rooms: {
             /** Name of the room */
             _id: string
@@ -798,12 +865,48 @@ declare global {
       }
     }
 
-    /** GET /api/experimental/nukes response */
+    /** `GET /api/experimental/nukes` response */
     interface ExperimentalNukesResponse extends Response {
+      /** {@link Nuke} objects grouped by shard name */
       nukes: { [shardName: string]: Nuke[] }
     }
 
-    /** GET /api/scoreboard/list response */
+    /**
+     * Response from `GET /api/warpath/battles` on a game server,
+     * or any `GET * /battles.json` endpoints on
+     * {@link https://voight-kampff.fly.dev/ | Voight-Kampff}
+     */
+    interface WarpathBattlesResponse extends Response {
+      /** ISO 8601 time at which the last scan was conducted */
+      timestamp: string
+      /** A list of conflicts indexed by shard */
+      shards: { [shardName: string]: WarpathBattle[] }
+    }
+
+    /** An individual battle from a {@link WarpathBattlesResponse} */
+    interface WarpathBattle {
+      /** Name of the room in which the battle is/was occurring */
+      room: string
+      /**
+       * Numeric string value from "0" to "5", where "5" is the
+       * highest-level conflict: https://screepspl.us/warpath/classifications/
+       */
+      classification: string
+      /** ISO 8601 time at which the conflict was first observed */
+      firstseen: string
+      /** ISO 8601 time at which the conflict was last observed */
+      lastseen: string
+      /** Tick at which the conflict was first observed */
+      firsttick: number
+      /** Tick at which the conflict was last observed */
+      lasttick: number
+      /** Username(s) of the attacking player(s) */
+      attackers: [string, ...string[]]
+      /** Username of the defending player */
+      defender: string
+    }
+
+    /** `GET /api/scoreboard/list` response */
     interface ScoreboardListResponse extends Response {
       meta: {
         /** The total number of players who have spawned on this season's map */
@@ -894,7 +997,7 @@ declare global {
     /** All HTTP methods used for Screeps API endpoints */
     type HttpMethod = 'GET' | 'POST'
 
-    /** IDs of stats that can be used with the POST /api/game/map-stats endpoint */
+    /** IDs of stats that can be used with the `POST /api/game/map-stats` endpoint */
     type MapStat
       = | 'owner0'
         | 'claim0'
@@ -1683,6 +1786,7 @@ interface _Decoration {
   __v: number
 }
 
+/** All available {@link  Flag} colors */
 export enum FlagColor {
   Red = 1,
   Purple = 2,

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -24,6 +24,7 @@ export class ConfigManager {
 
   /**
    * Search for config files and load
+   * @param serverName the name of the server to use from the credential file
    * @param opts see {@link LoadConfigOptions}
    * @returns a valid {@link Api.Config} if one was found, or null
    */

--- a/src/RawAPI.ts
+++ b/src/RawAPI.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import Debug from 'debug'
 import { EventEmitter } from 'node:events'
 import { setTimeout } from 'node:timers/promises'
@@ -12,19 +12,55 @@ const debugRateLimit = Debug('screepsapi:ratelimit')
 const debugRateLimitExceeded = Debug('screepsapi:ratelimitexceeded')
 
 const gunzipAsync = utils.promisify(zlib.gunzip)
-const inflateAsync = utils.promisify(zlib.inflate)
 
 const OFFICIAL_HISTORY_INTERVAL = 100
 const PRIVATE_HISTORY_INTERVAL = 20
 
 export class RawAPI extends EventEmitter {
+  /**
+   * This object exposes individual HTTP API endpoints as functions grouped by
+   * endpoint URL path. All of these endpoint functions are asynchronous.
+   *
+   * Some of endpoints behave differently on official servers (i.e. any server
+   * with the {@link https://screeps.com/ | screeps.com} hostname) than they do
+   * on unofficial/private servers. Any such known discrepancies are documented
+   * on each endpoint.
+   *
+   * Almost all endpoints require the user to be authenticated (see {@link auth})
+   * to use. Any known exceptions to this rule are documented.
+   *
+   * All endpoint functions are backed by {@link req}, which provides shared
+   * error handling logic, etc. If an endpoint does not have a corresponding
+   * function defined here, {@link req} may be called to access that endpoint
+   * directly (albeit without request parameter or response type annotations).
+   * Please consider submitting a PR to add functions for any missing endpoints!
+   * @example
+   * // To access the `GET /api/auth/me` endpoint:
+   * const me = await api.raw.auth.me()
+   * @see {@link Socket} for WebSocket API functionality
+   */
   readonly raw = {
-    /** GET /api/version */
+    /**
+     * Fetch basic information about a server, including versioning info,
+     * available shards, available features, and more.
+     *
+     * This endpoint does not require authentication.
+     *
+     * Endpoint: `GET /api/version`
+     */
     version: (): Promise<Api.VersionResponse> => {
       return this.req('GET', '/api/version')
     },
 
-    /** GET /api/authmod */
+    /**
+     * Describes the server mod used for authentication on unofficial servers.
+     *
+     * For official servers, the name of the mod is always `'official'`.
+     *
+     * This endpoint does not require authentication.
+     *
+     * Endpoint: `GET /api/authmod`
+     */
     authmod: (): Promise<Api.AuthModResponse> => {
       if (this.isOfficialServer()) {
         return Promise.resolve({ ok: 1, name: 'official' })
@@ -33,15 +69,27 @@ export class RawAPI extends EventEmitter {
     },
 
     /**
-     * Official:
-     * GET /room-history/${shard}/${room}/${tick}.json
-     * Private:
-     * GET /room-history
-     * @returns A json file with history data
+     * Fetch a chunk of history data for a single room.
+     *
+     * Official Endpoint: `GET /room-history/${shard}/${room}/${tick}.json`
+     * Unofficial Endpoint: `GET /room-history`
+     * @param room Name of the room for which to fetch history
+     * @param tick Tick for which history should be fetched
+     * @param shard The name of the shard to use (ignored by unofficial servers).
+     *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+     * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+     *  while using an official server
+     * @throws {Api.Error} if history is unsupported or the requested chunk is missing
+     * - HTTP 500: this is an unofficial server that does not record room history
+     * - HTTP 404: the requested history chunk does not exist
+     * @see {@link version} returns the history chunk size to expect
      */
     history: (room: string, tick: number, shard?: string): Promise<Api.RoomHistoryResponse> => {
-      shard ??= this.config.client.defaultShard
       if (this.isOfficialServer()) {
+        shard ??= this.config.client.defaultShard
+        if (shard === undefined) {
+          throw new Error('shard must be defined')
+        }
         tick -= tick % OFFICIAL_HISTORY_INTERVAL
         return this.req('GET', `/room-history/${shard}/${room}/${tick}.json`)
       } else {
@@ -50,298 +98,620 @@ export class RawAPI extends EventEmitter {
       }
     },
 
+    /** Endpoints that provide information about other servers */
     servers: {
       /**
-       * A list of curated community servers
-       * POST /api/servers/list
+       * Fetch a list of curated community servers.
+       *
+       * This endpoint does not require authentication.
+       *
+       * Endpoint: `POST /api/servers/list`
        */
       list: (): Promise<Api.ServerListResponse> => {
-        return this.req('POST', '/api/servers/list', {})
+        return this.req('POST', '/api/servers/list')
       }
     },
 
+    /** Endpoints for authenticating to the server or checking authentication status */
     auth: {
-      /** POST /api/auth/signin */
+      /**
+       * Authenticate to the server using email/password credentials.
+       *
+       * This authentication method has not worked on official servers
+       * since 2018, but it is still used for unofficial servers.
+       *
+       * Endpoint: `POST /api/auth/signin`
+       * @param email The email address used for registration
+       * @param password The password used for registration
+       */
       signin: (email: string, password: string): Promise<Api.AuthSigninResponse> => {
         return this.req('POST', '/api/auth/signin', { email, password })
       },
 
-      /** POST /api/auth/steam-ticket */
+      /**
+       * Authenticate via Steam SSO.
+       *
+       * Steam and Github SSO are the only permitted authentication methods
+       * on official servers.
+       *
+       * Endpoint: `POST /api/auth/steam-ticket`
+       * @param ticket Do you know what this does? If so, please submit a PR!
+       * @param useNativeAuth Do you know what this does? If so, please submit a PR!
+       */
       steamTicket: (ticket: unknown, useNativeAuth = false): Promise<Api.UnknownResponse> => {
         return this.req('POST', '/api/auth/steam-ticket', { ticket, useNativeAuth })
       },
 
-      /** GET /api/auth/me */
+      /**
+       * Fetch basic information about the authenticated user.
+       * Endpoint: `GET /api/auth/me`
+       */
       me: (): Promise<Api.AuthMeResponse> => {
         return this.req('GET', '/api/auth/me')
       },
 
       /**
        * Queries the status/permissions of an API token.
-       * Raises an error if the token is invalid / not recognized.
+       * Throws an error if the token is invalid / not recognized.
        *
-       * GET /api/auth/query-token
+       * Endpoint: `GET /api/auth/query-token`
+       * @param token The API token for which permissions should be queried
+       * @see {@link ScreepsAPI.token} for the API token currently in use by this client
        */
       queryToken: (token: string): Promise<Api.AuthQueryTokenResponse> => {
         return this.req('GET', '/api/auth/query-token', { token })
       }
     },
 
+    /** Endpoints for creating new user accounts */
     register: {
-      /** GET /api/register/check-email */
-      checkEmail: (email: string): Promise<Api.UnknownResponse> => {
+      /**
+       * Checks the availability of an email address.
+       *
+       * This endpoint does not require authentication.
+       *
+       * Endpoint: `GET /api/register/check-email`
+       * @param email The email address to check
+       * @returns If the exmail is available, returns {@link Api.Response}.
+       *  If the email is taken, returns {@link Api.ErrorResponse}
+       *  (`{ error: 'exists' }`).
+       */
+      checkEmail: (email: string): Promise<Api.Response | Api.ErrorResponse> => {
         return this.req('GET', '/api/register/check-email', { email })
       },
 
-      /** GET /api/register/check-username */
-      checkUsername: (username: string): Promise<Api.UnknownResponse> => {
+      /**
+       * Checks the availability of a username.
+       *
+       * This endpoint does not require authentication.
+       *
+       * Endpoint: `GET /api/register/check-username`
+       * @param username The username to check
+       * @returns If the username is available, returns {@link Api.Response}.
+       *  If the username is taken, returns {@link Api.ErrorResponse}
+       *  (`{ error: 'exists' }`).
+       */
+      checkUsername: (username: string): Promise<Api.Response | Api.ErrorResponse> => {
         return this.req('GET', '/api/register/check-username', { username })
       },
 
-      /** POST /api/register/set-username */
-      setUsername: (username: string): Promise<Api.UnknownResponse> => {
+      /**
+       * Endpoint: `POST /api/register/set-username`
+       * @param username The username to associated with this account
+       * @returns Please consider submitting a PR to document the success response.
+       *  If used for an account that is already set up, returns
+       *  {@link Api.ErrorResponse} (`{ error: 'username already set' }`).
+       */
+      setUsername: (username: string): Promise<Api.UnknownResponse | Api.ErrorResponse> => {
         return this.req('POST', '/api/register/set-username', { username })
       },
 
-      /** POST /api/register/submit */
-      submit: (username: string, email: string, password: string, modules: unknown): Promise<Api.UnknownResponse> => {
+      /**
+       * Create a new user account.
+       *
+       * Endpoint: `POST /api/register/submit`
+       * @param username The username to use for this new account
+       * @param email The email address to associate with this new account
+       * @param password The password to use for this new account.
+       *  It is unclear whether or not this is accepted or even allowed on official servers.
+       * @param modules Initial bot code to deploy for this user
+       */
+      submit: (
+        username: string,
+        email: string,
+        password: string,
+        modules?: Api.UserCodeModules
+      ): Promise<Api.UnknownResponse> => {
         return this.req('POST', '/api/register/submit', { username, email, password, modules })
       }
     },
 
+    /** Endpoints used to read or modify game state */
     game: {
       /**
-       * Fetches a stat for one or more rooms, along with
-       * basic information like its owner and RCL
+       * Fetch statistics for one or more rooms along with
+       * basic information like owner and RCL.
        *
-       * POST /api/game/map-stats
-       *
-       * @param rooms An array of room names
-       * @param statName the ID of the stat to fetch
-       * @param shard
+       * Endpoint: `POST /api/game/map-stats`
+       * @param rooms An array of one or more room names.
+       * @param statName The type of stat to fetch. See {@link Api.MapStat}.
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
        */
-      mapStats: async <S extends Api.MapStat>(rooms: string[], statName: S, shard?: string): Promise<Api.GameMapStatsResponse<S>> => {
+      mapStats: async <S extends Api.MapStat>(
+        rooms: string[],
+        statName: S,
+        shard?: string
+      ): Promise<Api.GameMapStatsResponse<S>> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/map-stats', { rooms, statName, shard })
       },
 
       /**
-       * POST /api/game/gen-unique-object-name
-       * @param type the type of object for which to generate the name (ex: "flag" or "spawn")
-       * @param shard
+       * Generate a name for a new room object.
+       *
+       * The generated name will be unique across all other objects of that
+       * type owned by the authenticated user on the specified shard.
+       *
+       * Endpoint: `POST /api/game/gen-unique-object-name`
+       * @param type The type of object for which to generate the name (ex: "flag" or "spawn")
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
        */
       genUniqueObjectName: (type: string, shard?: string): Promise<Api.GameGenUniqueNameResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/gen-unique-object-name', { type, shard })
       },
 
-      /** POST /api/game/check-unique-object-name */
+      /**
+       * Check whether or not a name for a room object is in use by any
+       * other room object of the same type on the specified shard.
+       *
+       * Endpoint: `POST /api/game/check-unique-object-name`
+       * @param type The type of object for which to check the name (ex: "flag" or "spawn")
+       * @param name The name to check
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       checkUniqueObjectName: (type: string, name: string, shard?: string): Promise<Api.UnknownResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/check-unique-object-name', { type, name, shard })
       },
 
-      /** POST /api/game/place-spawn */
-      placeSpawn: (room: string, x: number, y: number, name: string, shard?: string): Promise<Api.UnknownResponse> => {
+      /**
+       * Place the authenticated user's first {@link Api.StructureSpawn | spawn} structure.
+       *
+       * This operation is only permitted when the user's
+       * {@link Api.UserWorldStatusResponse.status | world status}
+       * is equal to `'empty'`.
+       *
+       * Endpoint: `POST /api/game/place-spawn`
+       * @param room Name of the room in which the spawn should be placed
+       * @param x X-coordinate of the spawn's room position
+       * @param y Y-coordinate of the spawn's room position
+       * @param name An optional name to assign to the placed spawn
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
+      placeSpawn: (room: string, x: number, y: number, name?: string, shard?: string): Promise<Api.UnknownResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/place-spawn', { name, room, x, y, shard })
       },
 
       /**
-       * - if the name is new, result.upserted[0]._id is the game id of the created flag
-       * - if not, this moves the flag and the response does not contain the id (but the id doesn't change)
-       * - `connection` looks like some internal MongoDB thing that is irrelevant to us
+       * Create a new flag or move an existing one with the specified name.
        *
-       * POST /api/game/create-flag
+       * Unlike the runtime API equivalent of this endpoint, room visibility
+       * is not required here.
+       *
+       * Endpoint: `POST /api/game/create-flag`
+       * @param room Name of the room in which the flag should be placed
+       * @param x X-coordinate of the flag's room position
+       * @param y Y-coordinate of the flag's room position
+       * @param name The name of the flag. If the name is already in use, the
+       *  current flag with this name will be moved to the specified position.
+       * @param color The color of the left side of the flag
+       * @param secondaryColor The color of the right side of the flag
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @returns A generic MongoDB upsert response:
+       * - If the name is new, `result.upserted[0]._id` is the game id of the created flag
+       * - If not, this moves the flag and the response does not contain the ID (but the ID doesn't change)
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
        */
-      createFlag: (room: string, x: number, y: number, name: string, color: FlagColor = 1, secondaryColor: FlagColor = 1, shard?: string): Promise<Api.DbUpsertedResponse> => {
+      createFlag: (
+        room: string,
+        x: number,
+        y: number,
+        name: string,
+        color: FlagColor = FlagColor.White,
+        secondaryColor: FlagColor = FlagColor.White,
+        shard?: string
+      ): Promise<Api.DbUpsertedResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/create-flag', { name, room, x, y, color, secondaryColor, shard })
       },
 
-      /** POST/api/game/gen-unique-flag-name */
+      /**
+       * Generate a name for a new flag.
+       *
+       * The generated name will be unique across all other flags
+       * owned by the authenticated user on the specified shard.
+       *
+       * Endpoint: `POST /api/game/gen-unique-flag-name`
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       genUniqueFlagName: (shard?: string): Promise<Api.GameGenUniqueNameResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/gen-unique-flag-name', { shard })
       },
 
-      /** POST /api/game/check-unique-flag-name */
+      /**
+       * Check whether or not a flag name is in use.
+       *
+       * Checks all existing flags owned by the authenticated user on
+       * the specified shard for one with the specified name.
+       *
+       * Endpoint: `POST /api/game/check-unique-flag-name`
+       * @param name The name to check
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       checkUniqueFlagName: (name: string, shard?: string): Promise<Api.UnknownResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/check-unique-flag-name', { name, shard })
       },
 
-      /** POST /api/game/change-flag-color */
-      changeFlagColor: (color: FlagColor = 1, secondaryColor: FlagColor = 1, shard?: string): Promise<Api.DbModifiedResponse> => {
+      /**
+       * Change the color of an existing flag.
+       *
+       * Endpoint: `POST /api/game/change-flag-color`
+       * @param color The color of the left side of the flag
+       * @param secondaryColor The color of the right side of the flag
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
+      changeFlagColor: (
+        color: FlagColor = FlagColor.White,
+        secondaryColor: FlagColor = FlagColor.White,
+        shard?: string
+      ): Promise<Api.DbModifiedResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/change-flag-color', { color, secondaryColor, shard })
       },
 
-      /** POST /api/game/remove-flag */
+      /**
+       * Delete a flag by name.
+       *
+       * Endpoint: `POST /api/game/remove-flag`
+       * @param room The name of the room in which the flag is placed
+       * @param name The name of the flag to remove
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       removeFlag: (room: string, name: string, shard?: string): Promise<Api.Response> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/remove-flag', { name, room, shard })
       },
 
       /**
-       * This method is used for a variety of actions, depending on the `name` and `intent` parameters
+       * Trigger an action on one or more objects.
        *
-       * POST /api/game/add-object-intent
+       * This endpoint is used for a variety of actions, depending on the `name` and `intent` parameters.
        *
+       * Endpoint: `POST /api/game/add-object-intent`
        * @param _id the ID of the object that should perform the intent
        * @param room the name of the room the object is in
        * @param name name of the intent (ex: 'move')
        * @param intent JSON string describing the target(s) of the intent (for actions like 'heal' or 'build')
-       *
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
        * @example remove flag: name = "remove", intent = {}
        * @example destroy structure: _id = "room", name = "destroyStructure", intent = [ {id: <structure id>, roomName, <room name>, user: <user id>} ]
 can destroy multiple structures at once
-        * @example suicide creep: name = "suicide", intent = {id: <creep id>}
-        * @example unclaim controller: name = "unclaim", intent = {id: <controller id>}
+       * @example suicide creep: name = "suicide", intent = {id: <creep id>}
+       * @example unclaim controller: name = "unclaim", intent = {id: <controller id>}
 intent can be an empty object for suicide and unclaim, but the web interface sends the id in it, as described
-        * @example remove construction site: name = "remove", intent = {}
-        */
-      addObjectIntent: (_id: string, room: string, name: string, intent?: string, shard?: string): Promise<Api.DbUpsertedResponse> => {
+       * @example remove construction site: name = "remove", intent = {}
+       */
+      addObjectIntent: (
+        _id: string,
+        room: string,
+        name: string,
+        intent?: string,
+        shard?: string
+      ): Promise<Api.DbUpsertedResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/add-object-intent', { _id, room, name, intent, shard })
       },
 
       /**
-       * POST /api/game/create-construction
-       * @param structureType the same value as one of the in-game STRUCTURE_* constants ('road', 'spawn', etc.)
+       * Create a {@link Api.ConstructionSite | construction site} for a new
+       * {@link Api.Structure | structure}.
+       *
+       * Unlike the runtime API equivalent of this endpoint, room visibility
+       * is not required here.
+       *
+       * Endpoint: `POST /api/game/create-construction`
+       * @param room Name of the room in which to place the site
+       * @param x X-coordinate of the site's room position
+       * @param y Y-coordinate of the site's room position
+       * @param structureType The type of structure to build (ex: 'road', 'powerSpawn')
+       * @param name An optional name to assign to the placed structure.
+       *  This should be undefined unless `structureType` is 'spawn'.
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
        */
-      createConstruction: (room: string, x: number, y: number, structureType: Api.BuildableStructureConstant, name: string, shard?: string): Promise<Api.GameCreateConstructionResponse> => {
+      createConstruction: (
+        room: string,
+        x: number,
+        y: number,
+        structureType: Api.BuildableStructureConstant,
+        name?: string,
+        shard?: string
+      ): Promise<Api.GameCreateConstructionResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/create-construction', { room, x, y, structureType, name, shard })
       },
 
       /**
-       * POST /api/game/set-notify-when-attacked
-       * @param enabled is either true or false (literal values, not strings)
+       * Enable or disable attack notifications on a single {@link Api.RoomObject | room object}.
+       *
+       * Endpoint: `POST /api/game/set-notify-when-attacked`
+       * @param _id ID of the room object
+       * @param enabled `true` to enable notifications, or `false` to disable notifications
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
        */
       setNotifyWhenAttacked: (_id: string, enabled = true, shard?: string): Promise<Api.DbModifiedResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/set-notify-when-attacked', { _id, enabled, shard })
       },
 
-      /** POST /api/game/create-invader */
-      createInvader: (room: string, x: number, y: number, size: 'Melee' | 'Ranged' | 'Healer', type: 'small' | 'big', boosted = false, shard?: string): Promise<Api.UnknownResponse> => {
+      /**
+       * Create an invader creep in a room claimed by the authenticated user.
+       *
+       * Create a single invader to test the defenses of one of your rooms.
+       * This can be called multiple times in succession to simulate a raid group.
+       *
+       * Invaders created by this endpoint will not drop any resources on death.
+       *
+       * This operation is only permitted on exit positions of rooms claimed
+       * by the authenticated user.
+       *
+       * Endpoint: `POST /api/game/create-invader`
+       * @param room Name of the room in which to spawn
+       * @param x X-coordinate of the invader's room position
+       * @param y Y-coordinate of the invader's room position
+       * @param size The body size of the invader. In real invasions, the small size
+       *  spawns in unclaimed and low-RCL rooms, while the large size spawns in
+       *  high-RCL rooms.
+       * @param type The role of the invader, which will determine its body
+       *  part types, boost types, and behavior.
+       * @param boosted If `true`, the invader will be spawned with boosted parts.
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
+      createInvader: (
+        room: string,
+        x: number,
+        y: number,
+        size: 'small' | 'big',
+        type: 'Melee' | 'Ranged' | 'Healer',
+        boosted = false,
+        shard?: string
+      ): Promise<Api.UnknownResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/create-invader', { room, x, y, size, type, boosted, shard })
       },
 
-      /** POST /api/game/remove-invader */
+      /**
+       * Remove an invader creep created by {@link createInvader}.
+       *
+       * This operation is only permitted on invaders created by
+       * the authenticated user via the {@link createInvader} endpoint.
+       *
+       * Endpoint: `POST /api/game/remove-invader`
+       * @param _id The ID of the invader creep to remove
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       removeInvader: (_id: string, shard?: string): Promise<Api.UnknownResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/game/remove-invader', { _id, shard })
       },
 
-      /** GET /api/game/time */
+      /**
+       * Fetch the current game time
+       *
+       * Endpoint: `GET /api/game/time`
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       time: (shard?: string): Promise<Api.GameTimeResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('GET', '/api/game/time', { shard })
       },
 
-      /** GET /api/game/world-size */
+      /**
+       * Fetch the width and height (in rooms) of the specified shard's world map.
+       *
+       * Endpoint: `GET /api/game/world-size`
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       worldSize: (shard?: string): Promise<Api.GameWorldSizeResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('GET', '/api/game/world-size', { shard })
       },
 
-      /** GET /api/game/room-decorations */
+      /**
+       * Fetch all active {@link Api.Decorations.Instance | decorations} for a specific room.
+       *
+       * Endpoint: `GET /api/game/room-decorations`
+       * @param room The name of the room
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       roomDecorations: (room: string, shard?: string): Promise<Api.GameRoomDecorationsResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('GET', '/api/game/room-decorations', { room, shard })
       },
 
-      /** GET /api/game/room-objects */
+      /**
+       * Fetch all {@link Api.RoomObject | room objects} present in a specific room.
+       *
+       * Endpoint: `GET /api/game/room-objects`
+       * @param room The name of the room
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       roomObjects: (room: string, shard?: string): Promise<Api.GameRoomObjectsResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('GET', '/api/game/room-objects', { room, shard })
       },
 
       /**
-       * GET /api/game/room-terrain
-       * Returns results in "encoded" form (see return type documentation)
+       * Fetch terrain data for a specific room and return it in an "encoded" format.
+       *
+       * Endpoint: `GET /api/game/room-terrain`
+       * @param room The name of the room
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       * @see {@link roomTerrainUnencoded} for an alternative response format
        */
       roomTerrain: (room: string, shard?: string): Promise<Api.GameRoomTerrainEncodedResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('GET', '/api/game/room-terrain', { room, encoded: 1, shard })
       },
 
       /**
-       * GET /api/game/room-terrain
-       * Returns results in "unencoded" form (see return type documentation)
+       * Fetch terrain data for a specific room and return it in an "unencoded" format.
+       *
+       * Endpoint: `GET /api/game/room-terrain`
+       * @param room The name of the room
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       * @see {@link roomTerrainEncoded} for an alternative response format
        */
       roomTerrainUnencoded: (room: string, shard?: string): Promise<Api.GameRoomTerrainUnencodedResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('GET', '/api/game/room-terrain', { room, shard })
       },
 
-      /** GET /api/game/room-status */
+      /**
+       * Look up the {@link Api.RoomStatus | status of a room}.
+       *
+       * Endpoint: `GET /api/game/room-status`
+       * @param room The name of the room
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       roomStatus: (room: string, shard?: string): Promise<Api.GameRoomStatusResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('GET', '/api/game/room-status', { room, shard })
@@ -350,62 +720,102 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
       /**
        * Get the authenticated user's stats for a room broken down by time.
        *
-       * GET /api/game/room-overview
-       *
-       * @param interval size of each time slot in minutes; only specific values are allowed:
+       * Endpoint: `GET /api/game/room-overview`
+       * @param room The name of the room
+       * @param interval Size of each time slot in minutes; only specific values are allowed:
        * - 8: 8 minutes each; 64 minutes total
        * - 180: 3 hours each; 24 hours total
        * - 1440: 24 hours each; 8 days total
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
        */
-      roomOverview: (room: string, interval: Api.RoomStatInterval = 8, shard?: string): Promise<Api.GameRoomOverviewResponse> => {
+      roomOverview: (
+        room: string,
+        interval: Api.RoomStatInterval = 8,
+        shard?: string
+      ): Promise<Api.GameRoomOverviewResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('GET', '/api/game/room-overview', { room, interval, shard })
       },
 
+      /**
+       * Endpoints for reading or modifying the state of the
+       * {@link https://docs.screeps.com/market.html | in-game market}
+       */
       market: {
         /**
          * Get an overview of market data for a shard.
+         *
          * Intershard market data is always included, if available.
          *
-         * GET /api/game/market/orders-index
+         * Endpoint: `GET /api/game/market/orders-index`
+         * @param shard The name of the shard to use (ignored by unofficial servers).
+         *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+         * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+         *  while using an official server
          */
         ordersIndex: (shard?: string): Promise<Api.GameMarketIndexResponse> => {
           shard ??= this.config.client.defaultShard
-          if (shard === undefined) {
+          if (this.isOfficialServer() && shard === undefined) {
             throw new Error('shard must be defined')
           }
           return this.req('GET', '/api/game/market/orders-index', { shard })
         },
 
-        /** GET /api/game/market/my-orders */
+        /**
+         * Fetch all unexpired market orders created by the authenticated user.
+         *
+         * Endpoint: `GET /api/game/market/my-orders`
+         */
         myOrders: (): Promise<Api.GameMarketMyOrdersResponse> => {
           return this.req('GET', '/api/game/market/my-orders').then(this.mapToShard)
         },
 
         /**
-         * GET /api/game/market/orders
-         * @param shard if {@link resourceType} is an {@link IntershardResourceConstant}, this must be set to `undefined`.
+         * Fetch all active market orders for a given resource type.
+         *
+         * Endpoint: `GET /api/game/market/orders`
+         * @param resourceType Any {@link Api.MarketResourceConstant | resource type}
+         * @param shard If {@link resourceType} is an {@link IntershardResourceConstant}, this must be set to `undefined`.
          *  {@link Api.ClientConfig.defaultShard} is ignored here for compatibility with intershard resources.
          */
         orders: (resourceType: Api.MarketResourceConstant, shard?: string): Promise<Api.GameMarketOrdersResponse> => {
           return this.req('GET', '/api/game/market/orders', { resourceType, shard })
         },
 
-        /** GET /api/game/market/stats */
+        /**
+         * Fetch market history data for a given resource type.
+         *
+         * Endpoint: `GET /api/game/market/stats`
+         * @param resourceType Any {@link Api.MarketResourceConstant | resource type}
+         * @param shard The name of the shard to use (ignored by unofficial servers).
+         *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+         * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+         *  while using an official server
+         */
         stats: (resourceType: Api.MarketResourceConstant, shard?: string): Promise<Api.GameMarketStatsResponse> => {
           shard ??= this.config.client.defaultShard
-          if (shard === undefined) {
+          if (this.isOfficialServer() && shard === undefined) {
             throw new Error('shard must be defined')
           }
           return this.req('GET', '/api/game/market/stats', { resourceType, shard })
         }
       },
 
+      /** Endpoints for querying information related to a server's shards */
       shards: {
-        /** GET /api/game/shards/info */
+        /**
+         * Fetch high-level data about all available shards on this server.
+         *
+         * This endpoint does not require authentication.
+         *
+         * Endpoint: `GET /api/game/shards/info`
+         */
         info: (): Promise<Api.GameShardsInfoResponse> => {
           return this.req('GET', '/api/game/shards/info')
         }
@@ -414,61 +824,101 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
 
     leaderboard: {
       /**
-       * GET /api/leaderboard/list
+       * Fetch the leaderboard rankings for a specific user.
+       *
+       * This endpoint does not require authentication.
+       *
+       * Endpoint: `GET /api/leaderboard/list`
+       * @param limit The number of user results to include per response
        * @param mode 'world' (control points) or 'power' (power processed)
+       * @param offset The index (starting at zero) of the first leaderboard
+       *  position that should be included in the response
        * @param season A date in the format `YYYY-MM`, NOT a seasonal world name/number
        */
-      list: (limit = 10, mode: 'world' | 'power' = 'world', offset: number | null = 0, season?: string): Promise<Api.LeaderboardListResponse> => {
+      list: (
+        limit = 10,
+        mode: Api.LeaderboardType = 'world',
+        offset: number | null = 0, season?: string
+      ): Promise<Api.LeaderboardListResponse> => {
         season ??= this.currentSeason()
         return this.req('GET', '/api/leaderboard/list', { limit, mode, offset, season })
       },
 
       /**
-       * GET /api/leaderboard/find
+       * Fetch the leaderboard rankings for a specific user.
+       *
+       * This endpoint does not require authentication.
+       *
+       * Endpoint: `GET /api/leaderboard/find`
+       * @param username The name of the user
        * @param mode 'world' (control points) or 'power' (power processed)
-       * @param season An optional date in the format YYYY-MM, if not supplied all ranks in all seasons is returned.
+       * @param season An optional date in the format YYYY-MM.
+       *  If undefined, the user's ranks for all seasons is returned.
        */
-      find: (username: string, mode: 'world' | 'power' = 'world', season?: string): Promise<Api.LeaderboardFindResponse> => {
+      find: (
+        username: string,
+        mode: Api.LeaderboardType = 'world',
+        season?: string
+      ): Promise<Api.LeaderboardFindResponse> => {
         return this.req('GET', '/api/leaderboard/find', { season, mode, username })
       },
 
       /**
-       * Get a list of all seasons for which leaderboard rankings exist
-       * GET /api/leaderboard/seasons
+       * Fetch a list of all seasons for which leaderboard rankings exist.
+       * Note that the "seasons" mentioned here are distinct from the official
+       * {@link https://screeps.com/season/#!/seasons/chronicle | seasonal world}
+       * competitions.
+       *
+       * This endpoint does not require authentication.
+       *
+       * Endpoint: `GET /api/leaderboard/seasons`
        */
       seasons: (): Promise<Api.LeaderboardSeasonsResponse> => {
         return this.req('GET', '/api/leaderboard/seasons')
       }
     },
 
+    /**
+     * Endpoints for {@link https://screeps.com/season/#!/seasons/chronicle | seasonal world} events.
+     * @see {@link scoreboard} for seasonal world scoreboard endpoints
+     */
     seasons: {
       /**
-       * Get data about the current season
-       * GET /api/seasons/current
+       * Fetch metadata for the current season. Only works on official servers
+       * when a seasonal world competition is active or about to start.
+       *
+       * Endpoint: `GET /api/seasons/current`
+       * @throws {Api.Error} HTTP 404 if called on an unofficial server
+       * @returns Metadata on the current season, or null if a seasonal world
+       *  competition is not active or about to start
        */
       current: (): Promise<Api.SeasonsCurrentResponse | null> => {
-        if (!this.isSeasonServer()) return Promise.resolve(null)
         return this.req('GET', '/api/seasons/current')
       }
     },
 
+    /**
+     * Endpoints for reading or modifying state about the authenticated user,
+     * or for looking up information on other users.
+     */
     user: {
       /**
-       * PTR only: unlock CPU for one week. Does nothing on non-PTR servers.
-       * POST /api/user/activate-ptr
+       * Unlock CPU on PTR for one week.
+       *
+       * Endpoint: `POST /api/user/activate-ptr`
+       * @returns an {@link Api.Response} on PTR, or an {@link Api.ErrorResponse}
+       *  (`{ error: 'not ptr' }`) on official servers that are not PTR.
+       * @throws {Api.Error} HTTP 404 on unofficial servers
        */
-      activatePtr: (): Promise<Api.Response> => {
-        // Without this check, an `{ error: 'not ptr' }` response is returned
-        // on MMO/season, and a 404 error is thrown on unofficial servers
-        if (!this.isPtrServer()) {
-          return Promise.resolve({ ok: 1 })
-        }
+      activatePtr: (): Promise<Api.Response | Api.ErrorResponse> => {
         return this.req('POST', '/api/user/activate-ptr')
       },
 
       /**
        * Update the authenticated user's {@link Badge}.
-       * POST /api/user/badge
+       *
+       * Endpoint: `POST /api/user/badge`
+       * @param badge The new user's new badge. See {@link Api.Badge}
        */
       badge: (badge: Api.Badge): Promise<Api.DbModifiedResponse> => {
         return this.req('POST', '/api/user/badge', { badge })
@@ -476,7 +926,9 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
 
       /**
        * Update the authenticated user's shard CPU limits.
-       * POST /api/user/cpu-shards
+       *
+       * Endpoint: `POST /api/user/cpu-shards`
+       * @param cpu The user's new shard CPU limits. See {@link Api.CpuShardLimits}
        */
       cpuShards: (cpu: Api.CpuShardLimits): Promise<Api.DbModifiedResponse> => {
         return this.req('POST', '/api/user/cpu-shards', { cpu })
@@ -485,83 +937,139 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
       /**
        * Abandon all of the authenticated user's rooms to allow them
        * to pick a new spawn room.
-       * POST /api/user/respawn
+       *
+       * Endpoint: `POST /api/user/respawn`
        */
       respawn: (): Promise<Api.UnknownResponse> => {
         return this.req('POST', '/api/user/respawn')
       },
 
-      /** POST /api/user/set-active-branch */
-      setActiveBranch: (branch: string, activeName: string): Promise<Api.UnknownResponse> => {
+      /**
+       * Update the code branch that will be used by the server or the simulator.
+       *
+       * Endpoint: `POST /api/user/set-active-branch`
+       * @param branch The name of the code branch to activate
+       * @param activeName The environment for which this code branch should be activated:
+       *  - 'activeWorld': activate branch on the server
+       *  - 'activeSim': activate branch on the simulator
+       * @see {@link ScreepsAPI.raw.user.branches} to list available branches
+       */
+      setActiveBranch: (branch: string, activeName: 'activeWorld' | 'activeSim'): Promise<Api.UnknownResponse> => {
         return this.req('POST', '/api/user/set-active-branch', { branch, activeName })
       },
 
-      /** POST /api/user/clone-branch */
-      cloneBranch: (branch: string, newName: string, defaultModules: unknown): Promise<Api.UnknownResponse> => {
+      /**
+       * Create a copy of a code branch.
+       *
+       * Endpoint: `POST /api/user/clone-branch`
+       * @param branch The name of the code branch to clone
+       * @param newName The name of the new code branch
+       * @param defaultModules Do you know what this does? If so, please submit a PR!
+       * @see {@link ScreepsAPI.raw.user.branches} to list available branches
+       */
+      cloneBranch: (
+        branch: string,
+        newName: string,
+        defaultModules: unknown
+      ): Promise<Api.UnknownResponse> => {
         return this.req('POST', '/api/user/clone-branch', { branch, newName, defaultModules })
       },
 
-      /** POST /api/user/delete-branch */
+      /**
+       * Delete a code branch.
+       *
+       * Endpoint: `POST /api/user/delete-branch`
+       * @param branch The name of the code branch to delete
+       */
       deleteBranch: (branch: string): Promise<Api.UnknownResponse> => {
         return this.req('POST', '/api/user/delete-branch', { branch })
       },
 
       /**
-       * Update the authenticated user's notification preferences
-       * POST /api/user/notify-prefs
+       * Update the authenticated user's notification preferences.
+       *
+       * Endpoint: `POST /api/user/notify-prefs`
+       * @param prefs See {@link Api.UserNotifyPrefsRequest}
        */
       notifyPrefs: (prefs: Api.UserNotifyPrefsRequest): Promise<Api.DbModifiedResponse> => {
         return this.req('POST', '/api/user/notify-prefs', prefs)
       },
 
       /**
-       * Mark tutorial as completed for the authenticated user
-       * POST /api/user/tutorial-done
+       * Mark tutorial as completed for the authenticated user.
+       *
+       * Endpoint: `POST /api/user/tutorial-done`
        */
       tutorialDone: (): Promise<Api.Response> => {
         return this.req('POST', '/api/user/tutorial-done')
       },
 
       /**
-       * Update the authenticated user's email address
-       * POST /api/user/email
+       * Update the authenticated user's email address.
+       *
+       * Endpoint: `POST /api/user/email`
+       * @param email The user's new email address
        */
       email: (email: string): Promise<Api.UnknownResponse> => {
         return this.req('POST', '/api/user/email', { email })
       },
 
-      /** GET /api/user/world-start-room */
-      worldStartRoom: (shard: string): Promise<Api.UserWorldStartRoomResponse> => {
+      /**
+       * Get the name of a room that should be centered on the
+       * authenticated user's map when opening the map view on the client
+       * with no coordinates.
+       *
+       * Endpoint: `GET /api/user/world-start-room`
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       */
+      worldStartRoom: (shard?: string): Promise<Api.UserWorldStartRoomResponse> => {
+        shard ??= this.config.client.defaultShard
         return this.req('GET', '/api/user/world-start-room', { shard })
       },
 
       /**
-       * Get the authenticated user's status on this server
-       * GET /api/user/world-status
+       * Get the authenticated user's status on the server.
+       *
+       * Endpoint: `GET /api/user/world-status`
        */
       worldStatus: (): Promise<Api.UserWorldStatusResponse> => {
         return this.req('GET', '/api/user/world-status')
       },
 
-      /** GET /api/user/branches */
+      /**
+       * Fetch a list of all code branches the authenticated user has
+       * on the server.
+       *
+       * Endpoint: `GET /api/user/branches`
+       */
       branches: (): Promise<Api.UserBranchesResponse> => {
         return this.req('GET', '/api/user/branches')
       },
 
+      /** Endpoints for downloading or uploading code */
       code: {
         /**
-         * Pull the authenticated user's code for a specific branch.
-         * Documentation: https://docs.screeps.com/commit.html
-         * GET /api/user/code
+         * Pull the authenticated user's code and WASM binaries for a
+         * specific branch.
+         *
+         * Endpoint: `GET /api/user/code`
+         * @param branch the name of the branch from which to pull code
+         * @see https://docs.screeps.com/commit.html
+         * @see {@link ScreepsAPI.raw.user.branches} to list available branches
          */
         get: (branch: string): Promise<Api.UserCodeGetResponse> => {
           return this.req('GET', '/api/user/code', { branch })
         },
 
         /**
-         * Push code to a branch for the authenticated user.
-         * Documentation: https://docs.screeps.com/commit.html
-         * POST /api/user/code
+         * Push code and WASM binaries to a branch for the authenticated user.
+         *
+         * Endpoint: `POST /api/user/code`
+         * @param params the code/binaries and target branch
+         * @param params.branch the name of the branch for which to upload code
+         * @param params.modules JavScript code and WASM binaries to upload keyed by module name
+         * @see https://docs.screeps.com/commit.html
          */
         set: (params: Api.UserCodeSetRequest): Promise<Api.UnknownResponse> => {
           return this.req('POST', '/api/user/code', params)
@@ -569,237 +1077,424 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
       },
 
       decorations: {
-        /** GET /api/user/decorations/inventory */
+        /** Endpoint: `GET /api/user/decorations/inventory` */
         inventory: (): Promise<Api.UserDecorationInventoryResponse> => {
           return this.req('GET', '/api/user/decorations/inventory')
         },
 
-        /** GET /api/user/decorations/themes */
+        /** Endpoint: `GET /api/user/decorations/themes` */
         themes: (): Promise<Api.UserDecorationThemesResponse> => {
           return this.req('GET', '/api/user/decorations/themes')
         },
 
-        /** POST /api/user/decorations/convert */
+        /**
+         * Destroy one or more owned {@link Api.Decorations.Instance | decorations}
+         * to refund a fraction of their pixelization cost.
+         *
+         * Endpoint: `POST /api/user/decorations/convert`
+         * @param decorations The IDs of one or more owned decorations
+         */
         convert: (decorations: string[]): Promise<Api.UnknownResponse> => {
           return this.req('POST', '/api/user/decorations/convert', { decorations })
         },
 
-        /** POST /api/user/decorations/pixelize */
+        /**
+         * Spend pixels to create one or more
+         * {@link Api.Decorations.Instance | decorations}.
+         *
+         * Endpoint: `POST /api/user/decorations/pixelize`
+         * @param count The number of decorations to generate.
+         * @param theme The theme from which to generate decorations.
+         *  Note that specifying a theme increases the pixelization cost.
+         *  Set to an empty string to create decorations from any theme.
+         */
         pixelize: (count: number, theme = ''): Promise<Api.UnknownResponse> => {
           return this.req('POST', '/api/user/decorations/pixelize', { count, theme })
         },
 
         /**
-         * Applies a decoration to a creep/object/room
-         * POST /api/user/decorations/activate
-         * @param _id the {@link DecorationInstance} to activate
-         * @param active values to assign to configurable {@link Decoration.props|properties}
+         * Apply / activate a {@link Api.Decorations.Instance | decoration} to a creep/object/room.
+         *
+         * Endpoint: `POST /api/user/decorations/activate`
+         * @param _id the ID of the decoration to activate
+         * @param active values to assign to configurable {@link Decoration.props | properties}
          */
         activate: (_id: string, active: object): Promise<Api.UnknownResponse> => {
           return this.req('POST', '/api/user/decorations/activate', { _id, active })
         },
 
         /**
-         * Removes one or more applied decoratoins
-         * POST /api/user/decorations/deactivate
+         * Remove / deactivate one or more active {@link Api.Decorations.Instance | decorations}.
+         *
+         * Endpoint: `POST /api/user/decorations/deactivate`
+         * @param decorations The IDs of one or more active decorations
          */
         deactivate: (decorations: string[]): Promise<Api.UnknownResponse> => {
           return this.req('POST', '/api/user/decorations/deactivate', { decorations })
         }
       },
 
-      /** GET /api/user/respawn-prohibited-rooms */
+      /**
+       * Look up the name of the room in which this player may not respawn.
+       *
+       * Endpoint: `GET /api/user/respawn-prohibited-rooms`
+       */
       respawnProhibitedRooms: (): Promise<Api.UserRespawnProhibitedRoomsResponse> => {
         return this.req('GET', '/api/user/respawn-prohibited-rooms')
       },
 
+      /**
+       * Endpoints for reading from or writing to
+       * {@link https://docs.screeps.com/global-objects.html#Memory-object | Memory}.
+       */
       memory: {
         /**
-         * Retrieves part or all of the authenticated user's Memory object
-         * GET /api/user/memory
-         * @param path the portion of the Memory JSON object to retrieve (ex: 'flags.Flag1');
-         *  if undefined/empty, returns the entire Memory object
+         * Retrieves part or all of the authenticated user's
+         * {@link https://docs.screeps.com/global-objects.html#Memory-object | Memory}.
+         *
+         * Endpoint: `GET /api/user/memory`
+         * @param path The portion of the Memory JSON object to retrieve (ex: 'flags.Flag1').
+         *  If undefined/empty, returns the entire Memory object.
+         * @param shard The name of the shard to use (ignored by unofficial servers).
+         *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+         * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+         *  while using an official server
          */
         get: (path?: string, shard?: string): Promise<Api.UserMemoryGetResponse> => {
           shard ??= this.config.client.defaultShard
-          if (shard === undefined) {
+          if (this.isOfficialServer() && shard === undefined) {
             throw new Error('shard must be defined')
           }
           return this.req('GET', '/api/user/memory', { path, shard })
         },
 
         /**
-         * POST /api/user/memory
-         * @param path the portion of the Memory JSON object to write (ex: 'flags.Flag1');
-         *  if undefined/empty, returns the entire Memory object
-         * @param shard
+         * Updates part or all of the authenticated user's
+         * {@link https://docs.screeps.com/global-objects.html#Memory-object | Memory}.
+         *
+         * Endpoint: `POST /api/user/memory`
+         * @param path The portion of the Memory JSON object to write (ex: 'flags.Flag1').
+         *  **WARNING: If undefined/empty, overwrites the entire Memory object.**
+         * @param value The value to write to the specified Memory path. This will
+         *  completely replace the previous value.
+         * @param shard The name of the shard to use (ignored by unofficial servers).
+         *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+         * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+         *  while using an official server
          */
         set: (path: string | undefined, value: unknown, shard?: string): Promise<Api.UserMemorySetResponse> => {
           shard ??= this.config.client.defaultShard
-          if (shard === undefined) {
+          if (this.isOfficialServer() && shard === undefined) {
             throw new Error('shard must be defined')
           }
           return this.req('POST', '/api/user/memory', { path, value, shard })
         },
 
+        /**
+         * Endpoints for reading from or writing to
+         * {@link https://docs.screeps.com/api/#RawMemory.segments | RawMemory.segments}.
+         */
         segment: {
           /**
-           * GET /api/user/memory-segment
-           * @param segment A number from 0-99
+           * Fetch the contents of one or more
+           * {@link https://docs.screeps.com/api/#RawMemory.segments | RawMemory.segments}.
+           *
+           * Endpoint: `GET /api/user/memory-segment`
+           * @param segment One or more segment IDs to read. Multiple IDs can be
+           *  specified in a single string by separating the IDs with commas.
+           * @param shard The name of the shard to use (ignored by unofficial servers).
+           *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+           * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+           *  while using an official server
+           * @example
+           * // Fetch a single segment
+           * api.raw.user.memory.segment.get(7, 'shard3')
+           * @example
+           * // Fetch a multiple segments with an ID array
+           * api.raw.user.memory.segment.get([7, '13'], 'shard3')
+           * @example
+           * // Fetch a multiple segments with a comma-delimited ID list
+           * api.raw.user.memory.segment.get('7,13,30', 'shard3')
            */
-          get: (segment: number | string, shard?: string): Promise<Api.UserMemorySegmentGetResponse> => {
+          get: (
+            segment: number | string | (number | string)[],
+            shard?: string
+          ): Promise<Api.UserMemorySegmentGetResponse> => {
             shard ??= this.config.client.defaultShard
-            if (shard === undefined) {
+            if (this.isOfficialServer() && shard === undefined) {
               throw new Error('shard must be defined')
             }
+
+            if (Array.isArray(segment)) {
+              segment = segment.map(s => s.toString()).join()
+            }
+
             return this.req('GET', '/api/user/memory-segment', { segment, shard })
           },
 
           /**
-           * POST /api/user/memory-segment
+           * Update the contents of a single
+           * {@link https://docs.screeps.com/api/#RawMemory.segments | RawMemory.segments}.
+           *
+           * Endpoint: `POST /api/user/memory-segment`
            * @param segment A number from 0-99
+           * @param data The data to write to the segment. Non-string values will be
+           *  serialized on the server side.
+           * @param shard The name of the shard to use (ignored by unofficial servers).
+           *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+           * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+           *  while using an official server
            */
-          set: (segment: number | string, data: unknown, shard?: string): Promise<Api.UnknownResponse> => {
+          set: (segment: number | string, data: unknown, shard?: string): Promise<Api.Response> => {
             shard ??= this.config.client.defaultShard
-            if (shard === undefined) {
+            if (this.isOfficialServer() && shard === undefined) {
               throw new Error('shard must be defined')
             }
+
+            if (segment.toString().includes(',')) {
+              throw new Error('Only one segment can be written per request')
+            }
+
             return this.req('POST', '/api/user/memory-segment', { segment, data, shard })
           }
         }
       },
 
+      /** Endpoints for reading or managing in-game messages */
       messages: {
         /**
-         * GET /api/user/messages/list?respondent={userId}
-         * @param respondent the long `_id` of the user, not the username
+         * Search for messages by user ID.
+         *
+         * Endpoint: `GET /api/user/messages/list`
+         * @param respondent The long `_id` of the user, not the username
          */
         list: (respondent: string): Promise<Api.UserMessagesListResponse> => {
           return this.req('GET', '/api/user/messages/list', { respondent })
         },
 
         /**
-         * Gets the last message from every thread this user is in
-         * GET /api/user/messages/index
+         * Fetch the last message from every thread in the authenticated user's inbox.
+         *
+         * Endpoint: `GET /api/user/messages/index`
          */
         index: (): Promise<Api.UserMessagesIndexResponse> => {
           return this.req('GET', '/api/user/messages/index')
         },
 
-        /** GET /api/user/messages/unread-count */
+        /**
+         * Fetch the authenticated user's number of unread messages.
+         *
+         * Endpoint: `GET /api/user/messages/unread-count`
+         */
         unreadCount: (): Promise<Api.UserMessagesUnreadCountResponse> => {
           return this.req('GET', '/api/user/messages/unread-count')
         },
 
         /**
-         * POST /api/user/messages/send
-         * @param respondent the long `_id` of the user, not the username
+         * Send a message on behalf of the authenticated user.
+         *
+         * Endpoint: `POST /api/user/messages/send`
+         * @param respondent The long `_id` of the user, not the username
+         * @param text The text of the message to send
          */
         send: (respondent: string, text: string): Promise<Api.UnknownResponse> => {
           return this.req('POST', '/api/user/messages/send', { respondent, text })
         },
 
         /**
-         * POST /api/user/messages/mark-read
-         * @param id
+         * Mark the authenticated user's copy of a message as read.
+         *
+         * Endpoint: `POST /api/user/messages/mark-read`
+         * @param id The ID of the message to mark as read
          */
         markRead: (id: string): Promise<Api.UserMessagesMarkReadResponse> => {
           return this.req('POST', '/api/user/messages/mark-read', { id })
         }
       },
 
-      /** GET /api/user/find?username={username} */
+      /**
+       * Find a user by name.
+       *
+       * Endpoint: `GET /api/user/find`
+       * @param username The complete username of the user
+       * @see {@link findById} to find a user by ID instead of username
+       */
       find: (username: string): Promise<Api.UserFindResponse> => {
         return this.req('GET', '/api/user/find', { username })
       },
 
-      /** GET /api/user/find?id={userId} */
+      /**
+       * Find a user by ID.
+       *
+       * Endpoint: `GET /api/user/find`
+       * @param id The ID of the user
+       * @see {@link find} to find a user by username instead of ID
+       */
       findById: (id: string): Promise<Api.UserFindResponse> => {
         return this.req('GET', '/api/user/find', { id })
       },
 
-      /** GET /api/user/stats */
-      stats: (interval: number): Promise<Api.UnknownResponse> => {
-        return this.req('GET', '/api/user/stats', { interval })
+      /**
+       * Look up stats for a user.
+       *
+       * Endpoint: `GET /api/user/stats`
+       * @param id ID of the user
+       * @param interval The time interval in minutes (divided by 8); only specific values are allowed:
+       * - 8: Past hour (actually 64 minutes)
+       * - 180: Past day
+       * - 1440: Past week (actually 8 days)
+       * @see {@link overview} for a more detailed version for the authenticated user
+       */
+      stats: (id: string, interval: Api.RoomStatInterval): Promise<Api.UserStatsResponse> => {
+        return this.req('GET', '/api/user/stats', { id, interval })
       },
 
       /**
-       * Find all rooms claimed by the specified player.
-       * GET /api/user/rooms
+       * Find all rooms claimed by the specified user.
+       *
+       * Endpoint: `GET /api/user/rooms`
+       * @param id The ID of the user
        */
       rooms: (id: string): Promise<Api.UserRoomsResponse> => {
         return this.req('GET', '/api/user/rooms', { id }).then(this.mapToShard)
       },
 
       /**
-       * Get an overview of the authenticated user's stats broken down by room and time
-       * GET /api/user/overview
-       * @param interval size of each time slot in minutes; only specific values are allowed:
+       * Get an overview of the authenticated user's stats broken down by room and time.
+       *
+       * Endpoint: `GET /api/user/overview`
+       * @param interval Size of each time slot in minutes; only specific values are allowed:
        * - 8: 8 minutes each; 64 minutes total
        * - 180: 3 hours each; 24 hours total
        * - 1440: 24 hours each; 8 days total
-       * @param statName the stat to view for this user
+       * @param statName The stat to view for this user
        */
-      overview: (interval: Api.RoomStatInterval = 8, statName: Api.RoomStat = 'energyControl'): Promise<Api.UserOverviewResponse> => {
+      overview: (
+        interval: Api.RoomStatInterval = 8,
+        statName: Api.RoomStat = 'energyControl'
+      ): Promise<Api.UserOverviewResponse> => {
         return this.req('GET', '/api/user/overview', { interval, statName })
       },
 
       /**
-       * GET /api/user/money-history
+       * Fetch a list of the authenticated user's most recent market transactions.
+       *
+       * Endpoint: `GET /api/user/money-history`
        * @param page Used for pagination
        */
       moneyHistory: (page = 0): Promise<Api.UserMoneyHistoryResponse> => {
         return this.req('GET', '/api/user/money-history', { page })
       },
 
-      /** POST /api/user/console */
+      /**
+       * Evaluate a JavaScript expression in the context of the authenticated
+       * user's bot's runtime environment.
+       *
+       * This expression is evaluated after the user's loop function runs.
+       * CPU costs and limits apply as they would to code in the loop function.
+       *
+       * Endpoint: `POST /api/user/console`
+       * @param expression The JavaScript expression to evaluate.
+       * @param shard The name of the shard to use (ignored by unofficial servers).
+       *  Defaults to {@link Api.ClientConfig.defaultShard} if undefined.
+       * @throws {Error} if shard and {@link Api.ClientConfig.defaultShard} are undefined
+       *  while using an official server
+       */
       console: (expression: string, shard?: string): Promise<Api.UserConsoleResponse> => {
         shard ??= this.config.client.defaultShard
-        if (shard === undefined) {
+        if (this.isOfficialServer() && shard === undefined) {
           throw new Error('shard must be defined')
         }
         return this.req('POST', '/api/user/console', { expression, shard })
       },
 
-      /** GET /api/user/name */
+      /**
+       * Fetch the authenticated user's username.
+       *
+       * Endpoint: `GET /api/user/name`
+       */
       name: (): Promise<Api.UserNameResponse> => {
         return this.req('GET', '/api/user/name')
       }
     },
 
+    /**
+     * Endpoints that are not yet considered stable. Their request parameters
+     * and response formats are subject to change without warning, and they
+     * may not be available on all servers.
+     *
+     * Currently, all endpoints in this category are used to query for
+     * current/recent PVP activity.
+     * @see {@link warpath} for similar endpoints
+     */
     experimental: {
       /**
        * Find rooms where attack actions have recently occurred
-       * (including combat actions against NPCs)
-       * GET /api/experimental/pvp
-       * @param interval minimum time (in ticks?) since last combat action
+       * (including combat actions against NPCs).
+       *
+       * Endpoint: `GET /api/experimental/pvp`
+       * @param interval Minimum time (in ticks?) since last combat action
        */
       pvp: (interval = 100): Promise<Api.ExperimentalPvpResponse> => {
         return this.req('GET', '/api/experimental/pvp', { interval }).then(this.mapToShard)
       },
 
       /**
-       * Find all active nuclear launches
-       * GET /api/experimental/nukes
+       * Find all active nuclear launches.
+       *
+       * Endpoint: `GET /api/experimental/nukes`
        */
       nukes: (): Promise<Api.ExperimentalNukesResponse> => {
         return this.req('GET', '/api/experimental/nukes').then(this.mapToShard)
       }
     },
 
+    /**
+     * Endpoints for querying current/recent PVP activity by room.
+     *
+     * These may not be implemented on all servers. Most notably, they are not
+     * available on official servers, but the third-party service
+     * {@link https://voight-kampff.fly.dev/ | Voight-Kampff} provides these
+     * and more for official servers and popular community servers.
+     * @see {@link experimental} for similar endpoints
+     */
     warpath: {
       /**
-       * GET /api/warpath/battles
-       * @param interval
+       * Find active/recent battles by room and classified by conflict intensity.
+       *
+       * This endpoint is unavailable on official servers, but the same data
+       * is available via {@link https://voight-kampff.fly.dev/ | Voight-Kampff}.
+       *
+       * Endpoint: `GET /api/warpath/battles`
+       * @param interval Minimum time (in ticks?) since last observed PVP activity
+       * @see {@link https://screepspl.us/warpath/classifications/ | Warpath Conflict Classifications} for
+       *  the criteria used to assign conflict levels
        */
       battles: (interval = 100): Promise<Api.UnknownResponse> => {
         return this.req('GET', '/api/warpath/battles', { interval })
       }
     },
 
+    /**
+     * Endpoints for querying scoreboard results. This appears to only be relevant
+     * to {@link https://screeps.com/season/#!/seasons/chronicle | seasonal world}
+     * competitions/events.
+     * @see {@link seasons} for seasonal world metadata endpoints
+     * @see {@link leaderboards} for non-seasonal leaderboard endpoints
+     */
     scoreboard: {
-      /** GET /api/scoreboard/list */
-      list: (limit = 20, offset = 0): Promise<Api.ScoreboardListResponse> => {
+      /**
+       * Query scoreboard results. This appears to only be relevant to
+       * {@link https://screeps.com/season/#!/seasons/chronicle | seasonal world}
+       * competitions/events.
+       *
+       * Endpoint: `GET /api/scoreboard/list`
+       * @param offset The index (starting at zero) of the first leaderboard
+       *  position that should be included in the response
+       * @param limit The number of users to return per request.
+       *  The maximum valid value is 20.
+       */
+      list: (offset = 0, limit = 20): Promise<Api.ScoreboardListResponse> => {
         return this.req('GET', '/api/scoreboard/list', { limit, offset })
       }
     }
@@ -846,7 +1541,10 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
     return !!(/screeps\.com\/ptr/.exec(this.config.server.url))
   }
 
-  protected mapToShard <R extends Response>(this: void, res: R & { shards?: unknown, list?: unknown, rooms?: unknown }): R {
+  protected mapToShard <R extends Response>(
+    this: void,
+    res: R & { shards?: unknown, list?: unknown, rooms?: unknown }
+  ): R {
     res.shards ??= {
       privSrv: res.list ?? res.rooms
     }
@@ -854,8 +1552,14 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
   }
 
   /**
-   * Authenticate to the server using the email and password in
-   * `this.config.server`.
+   * Authenticate to the server using the email and password from the provided
+   * {@link ServerConfig}.
+   *
+   * Typically, this should not be called directly; it will be triggered
+   * automatically when a request is made to an endpoint that requires
+   * authentication.
+   * @param cause if provided, will be attached to the error thrown when
+   *  authentication credentials are missing
    */
   async auth(cause?: unknown) {
     // Skip if already authenticating via API token
@@ -874,6 +1578,22 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
     return res
   }
 
+  /**
+   * Send an API request to the server.
+   *
+   * Typically, this should not be called directly. Instead, use the appropriate
+   * function from {@link raw} to get request parameter and response body types.
+   * If an endpoint you rely on is not in {@link raw}, please consider
+   * submitting a PR to implement it.
+   * @param method The HTTP method to use
+   * @param path The URL path of the endpoint. This will be appeneded to
+   *  {@link ServerConfig.url}. Request parameters should be included for
+   *  `GET` requests.
+   * @param body The body of the request (POST only)
+   * @param retriesAttempted The number of retries already attempted due to
+   *  HTTP 429 errors. This argument should not be provided by consumers.
+   * @returns The parsed response body
+   */
   async req(
     method: Api.HttpMethod,
     path: string,
@@ -964,7 +1684,7 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
         }
       }
 
-      if ((err as { response?: AxiosResponse }).response) {
+      if (err instanceof AxiosError) {
         const details = {
           params: {},
           data: res.data as string,
@@ -977,26 +1697,25 @@ intent can be an empty object for suicide and unclaim, but the web interface sen
           Object.assign(details.params, res.config?.params as object ?? {})
         }
 
-        throw new Error(JSON.stringify(details, undefined, 2), { cause: err })
+        const message = err instanceof Error
+          ? `${err.name}: ${err.message}: ${err.stack}`
+          : String(err)
+        const apiErr = new Error(message)
+        Object.assign(apiErr as Api.Error, details)
+        throw err
       }
 
       throw err
     }
   }
 
-  async gz(data: string): Promise<unknown> {
+  protected async gz(data: string): Promise<unknown> {
     const buf = Buffer.from(data.slice(3), 'base64')
     const ret = await gunzipAsync(buf)
     return JSON.parse(ret.toString())
   }
 
-  async inflate(data: string): Promise<unknown> {
-    const buf = Buffer.from(data.slice(3), 'base64')
-    const ret = await inflateAsync(buf)
-    return JSON.parse(ret.toString())
-  }
-
-  buildRateLimit(method: Api.HttpMethod, path: string, res: RateLimitResponse) {
+  protected buildRateLimit(method: Api.HttpMethod, path: string, res: RateLimitResponse) {
     const {
       headers: {
         'x-ratelimit-limit': limit,

--- a/src/ScreepsAPI.ts
+++ b/src/ScreepsAPI.ts
@@ -2,31 +2,56 @@ import { ConfigManager, DEFAULT_CLIENT_CONFIG } from './ConfigManager'
 import { RawAPI } from './RawAPI'
 import { Socket } from './Socket'
 
-interface RateLimit {
-  limit: number
-  period: 'minute' | 'hour' | 'day'
-  remaining: number
-  reset: number
-  toReset: number
+declare global {
+  namespace Api {
+    /**
+     * Rate limit state for an individual HTTP API endpoint.
+     * This can be read via {@link ScreepsAPI.rateLimit}
+     */
+    interface RateLimit {
+      limit: number
+      period: 'minute' | 'hour' | 'day'
+      remaining: number
+      reset: number
+      toReset: number
+    }
+  }
 }
 
 type RateLimits = {
-  global: RateLimit
+  global: Api.RateLimit
 } & {
-  [method in Api.HttpMethod]: { [path: string]: RateLimit }
+  [method in Api.HttpMethod]: {
+    [path: string]: Api.RateLimit
+  }
 }
 
 const configManager = new ConfigManager()
 
+/**
+ * Provides access to the Screeps HTTP API.
+ *
+ * Instances should typically be initialized via {@link ScreepsAPI.fromConfig},
+ * but the constructor can also be called directly if you prefer to handle
+ * loading the credentials and configuration options yourself.
+ *
+ * {@include ../docs/rate-limits.md}
+ * @see {@link raw} for a list of all known/implemented endpoints.
+ * @see {@link Socket} for the WebSocket API client (accessible via {@link ScreepsAPI.socket})
+ */
 export class ScreepsAPI extends RawAPI {
   /**
    * Search for a config/credential file and initializes the client from the first file found.
-   * If a valid config is loaded and email/password auth is being used, authenticate automatically.
-   * The client can also be initialized by passing a configuration object directly to the constructor.
    *
-   * @param serverName the property name of the server object to use from the config file
-   * @param opts see {@link Api.LoadConfigOptions}
-   * @throws if the selected config file is invalid or if no config files are found
+   * Authentication will occur automatically if email/password credentials
+   * are provided in lieu of an API token.
+   *
+   * Alternatively, the client can be initialized by passing a configuration
+   * object directly to the constructor.
+   * @param serverName The property name of the server object to use from the config file
+   * @param opts See {@link Api.LoadConfigOptions}
+   * @returns A configured and authenticated {@link ScreepsAPI} instance
+   * @throws {Error} if the selected config file is invalid or if no config files are found
    */
   static async fromConfig(serverName: string, opts?: Api.LoadConfigOptions): Promise<ScreepsAPI> {
     const config = await configManager.getConfig(serverName, opts)
@@ -107,6 +132,13 @@ export class ScreepsAPI extends RawAPI {
     return this.rateLimits[method][path] || this.rateLimits.global
   }
 
+  /**
+   * Generate an URL that can be opened in a browser to reset rate limits
+   * for all endpoints.
+   *
+   * The generated URL is specific to the API token currently in use.
+   * @throws {Error} if no API token is available.
+   */
   get rateLimitResetUrl() {
     if (!this.token) throw new Error('API token not found')
     return `https://screeps.com/a/#!/account/auth-tokens/noratelimit?token=${this.token.slice(
@@ -115,7 +147,13 @@ export class ScreepsAPI extends RawAPI {
     )}`
   }
 
-  async me(): Promise<Exclude<typeof this._user, undefined>> {
+  /**
+   * Fetch and memoize information about the authenticated user.
+   * @returns If using an API token with full permissions, this returns
+   * {@link Api.AuthMeResponse}. Otherwise, it returns
+   * {@link Api.UserFindResponse.user}.
+   */
+  async me(): Promise<Api.AuthMeResponse | Api.UserFindResponse['user']> {
     if (this._user) return this._user
     const tokenInfo = await this.tokenInfo()
     if (tokenInfo.full) {
@@ -129,8 +167,9 @@ export class ScreepsAPI extends RawAPI {
   }
 
   /**
-   * Fetch permissions and other information about the API token
-   * currently being used by this client
+   * Fetch and memoize permissions and other information about the API token
+   * currently being used by this client.
+   * @returns The "token" field from {@link Api.AuthQueryTokenResponse}
    */
   async tokenInfo(): Promise<Api.TokenInfo> {
     if (!this.token) {
@@ -152,51 +191,66 @@ export class ScreepsAPI extends RawAPI {
     return this._tokenInfo
   }
 
+  /**
+   * Fetch and memoize the authenticated user's ID
+   * @returns the current user's ID string
+   */
   async userID() {
     const user = await this.me()
     return user._id
   }
 
+  /** @inheritdoc */
   get history() {
     return this.raw.history
   }
 
+  /** @inheritdoc */
   get authmod() {
     return this.raw.authmod
   }
 
+  /** @inheritdoc */
   get version() {
     return this.raw.version
   }
 
+  /** @inheritdoc */
   get time() {
     return this.raw.game.time
   }
 
+  /** @inheritdoc */
   get leaderboard() {
     return this.raw.leaderboard
   }
 
+  /** @inheritdoc */
   get market() {
     return this.raw.game.market
   }
 
+  /** @inheritdoc */
   get registerUser() {
     return this.raw.register.submit
   }
 
+  /** @inheritdoc */
   get code() {
     return this.raw.user.code
   }
 
+  /** @inheritdoc */
   get memory() {
     return this.raw.user.memory
   }
 
+  /** @inheritdoc */
   get segment() {
     return this.raw.user.memory.segment
   }
 
+  /** @inheritdoc */
   get console() {
     return this.raw.user.console
   }

--- a/src/Socket.ts
+++ b/src/Socket.ts
@@ -2,20 +2,54 @@ import Debug from 'debug'
 import { EventEmitter } from 'node:events'
 import { setTimeout } from 'node:timers/promises'
 import { URL } from 'node:url'
+import utils from 'node:util'
 import WebSocket from 'ws'
+import zlib from 'zlib'
 import { ScreepsAPI } from './ScreepsAPI'
 
 const debug = Debug('screepsapi:socket')
 
-interface SocketOptions {
-  reconnect: boolean
-  resubscribe: boolean
-  keepAlive: boolean
-  maxRetries: number
-  maxRetryDelay: number
+const inflateAsync = utils.promisify(zlib.inflate)
+
+declare global {
+  namespace Api {
+    /**
+     * Configuration options for {@link Socket}.
+     * These are provided when calling {@link Socket.connect}.
+     * @see {@link SOCKET_DEFAULTS} for default values
+     */
+    export interface SocketOptions {
+      /**
+       * If enabled, {@link Socket} will call {@link reconnect} automatically
+       * when disconnected.
+       */
+      reconnect: boolean
+      /**
+       * If enabled, all previous subscriptions will be recreated
+       * after successfully reconnecting.
+       */
+      resubscribe: boolean
+      /**
+       * If enabled, ping the server periodically to prevent the connection
+       * from being closed.
+       */
+      keepAlive: boolean
+      /**
+       * The maximum number of connection attempts to make before
+       * throwing an error in {@link Socket.reconnect}.
+       */
+      maxRetries: number
+      /**
+       * The maximum delay (in milliseconds) before a retry attempt
+       * in {@link Socket.reconnect}.
+       */
+      maxRetryDelay: number
+    }
+  }
 }
 
-const DEFAULTS: SocketOptions = {
+/** Default {@link Api.SocketOptions} used by {@link Socket.connect} */
+export const SOCKET_DEFAULTS: Readonly<Api.SocketOptions> = {
   reconnect: true,
   resubscribe: true,
   keepAlive: true,
@@ -23,23 +57,47 @@ const DEFAULTS: SocketOptions = {
   maxRetryDelay: 60 * 1000 // in milli-seconds
 }
 
+/**
+ * Provides access to the Screeps WebSocket API.
+ *
+ * {@include ../docs/Websocket_endpoints.md}
+ * @see {@link ScreepsAPI} for the HTTP API client
+ */
 export class Socket extends EventEmitter {
   api: ScreepsAPI
-  opts: SocketOptions
+  opts: Api.SocketOptions
   ws?: WebSocket
   authed = false
   connected = false
   reconnecting = false
 
   private keepAliveInter?: NodeJS.Timeout
+  /**
+   * Pending messages to send once connected/authenticated.
+   * @hidden
+   */
   private __queue: (string | WebSocket.RawData)[] = []
+  /**
+   * Pending subscriptions to request once connected/authenticated
+   * @hidden
+   */
   private __subQueue: (string | WebSocket.RawData)[] = []
-  private __subs: { [path: string]: number } = {}
+  /**
+   * The number of subscriber callbacks by event type
+   * @hidden
+   */
+  private __subs: { [event: string]: number } = {}
 
+  /**
+   * Initializes a new WebSocket API client. Do not call this directly.
+   * Instead, use the instance from {@link ScreepsAPI.socket}.
+   * @param api The HTTP client instance with which config and auth credentials
+   *  should be shared
+   */
   constructor(api: ScreepsAPI) {
     super()
     this.api = api
-    this.opts = Object.assign({}, DEFAULTS)
+    this.opts = Object.assign({}, SOCKET_DEFAULTS)
     this.on('error', console.error)
     this.reset()
     this.on('auth', (ev: AuthEvent) => {
@@ -49,31 +107,39 @@ export class Socket extends EventEmitter {
         }
         clearInterval(this.keepAliveInter)
         if (this.opts.keepAlive) {
-          this.keepAliveInter = setInterval(() => this.ws?.ping(1), 10000)
+          this.keepAliveInter = setInterval(() => this.ws?.ping(1), 10_000)
         }
       }
     })
   }
 
-  reset() {
+  /** Initialize (or re-initialize) all client state */
+  private reset() {
     this.authed = false
     this.connected = false
     this.reconnecting = false
     clearInterval(this.keepAliveInter)
     delete this.keepAliveInter
-    this.__queue = [] // pending messages  (to send once authenticated)
-    this.__subQueue = [] // pending subscriptions (to request once authenticated)
-    this.__subs = {} // number of callbacks for each subscription
+    this.__queue = []
+    this.__subQueue = []
+    this.__subs = {}
   }
 
-  async connect(opts = {}) {
-    Object.assign(this.opts, opts)
+  /**
+   * Connect to the server and immediately attempt to authenticate.
+   *
+   * If successful, any queued messages will be sent automatically.
+   * @param opts WebSocket API client options. See {@link Api.SocketOptions}.
+   * @throws {Error} if an API token is not available due to missing auth credentials
+   */
+  async connect(opts?: Partial<Api.SocketOptions>) {
+    Object.assign(this.opts, opts ?? {})
     if (!this.api.token) {
       await this.api.auth(
         new Error('No token! Call api.auth() before connecting the socket!')
       )
     }
-    return await new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
       const baseURL = this.api.config.server.url.replace('http', 'ws')
       const wsurl = new URL('socket/websocket', baseURL)
       this.ws = new WebSocket(wsurl)
@@ -114,6 +180,16 @@ export class Socket extends EventEmitter {
     })
   }
 
+  /**
+   * Reconnect to the server using current client settings.
+   *
+   * Upon success, all previous subscriptions will be reestablished
+   * (if {@link Api.SocketOptions.resubscribe} is enabled).
+   *
+   * Up to {@link Api.SocketOptions.maxRetries} connections will be attempted
+   * with exponential backoff.
+   * @throws {Error} if the maximum number of retry attempts is exceeded
+   */
   async reconnect() {
     if (this.reconnecting) {
       return
@@ -147,20 +223,28 @@ export class Socket extends EventEmitter {
     }
   }
 
+  /** Close the connection and clear all queued messages. */
   disconnect() {
-    if (!this.ws) return
     debug('disconnect')
     clearInterval(this.keepAliveInter)
-    this.ws.removeAllListeners() // remove listeners first or we may trigger reconnection & Co.
-    this.ws.terminate()
+    if (this.ws) {
+      // Remove listeners first or we may trigger reconnection / etc
+      this.ws.removeAllListeners()
+      this.ws.terminate()
+    }
     this.reset()
     this.emit('disconnected')
   }
 
-  async handleMessage(rawMsg: string | { data: string }) {
+  /**
+   * Process an incoming message (normalize/inflate message data, etc),
+   * then emit events to notify the relevant subscribers.
+   * @param rawMsg The raw message content sent by the server
+   */
+  private async handleMessage(rawMsg: string | { data: string }) {
     let msg = typeof rawMsg === 'object' ? rawMsg.data : rawMsg // Handle ws/browser difference
     if (msg.startsWith('gz:')) {
-      msg = await this.api.inflate(msg) as string
+      msg = await this.inflate(msg) as string
     }
     debug(`message ${msg}`)
     if (msg.startsWith('[')) {
@@ -188,10 +272,35 @@ export class Socket extends EventEmitter {
     }
   }
 
-  gzip(bool: boolean) {
-    this.send(`gzip ${bool ? 'on' : 'off'}`)
+  private async inflate(data: string): Promise<unknown> {
+    const buf = Buffer.from(data.slice(3), 'base64')
+    const ret = await inflateAsync(buf)
+    return JSON.parse(ret.toString())
   }
 
+  /**
+   * Enable/disable gzip compression/deflation of messages from the server.
+   *
+   * Regardless of whether this is enabled or not, {@link Socket} will
+   * automatically inflate any compressed messages before notifying subscribers.
+   * @param enabled `true` to enable compression; `false` to disable it
+   */
+  gzip(enabled: boolean) {
+    this.send(`gzip ${enabled ? 'on' : 'off'}`)
+  }
+
+  /**
+   * Send a message to the server.
+   *
+   * If the client is not currently connected, the message will be queued
+   * to be sent when the connection is established.
+   *
+   * This should only be called directly if the desired functionality is not
+   * already implemented as another method on {@link Socket}. If you have a
+   * use case for calling `send` directly, please consider submitting a PR
+   * to add the feature to {@link Socket}.
+   * @param data the message to send
+   */
   send(data: string | WebSocket.RawData) {
     if (!this.connected || !this.ws) {
       this.__queue.push(data)
@@ -200,7 +309,12 @@ export class Socket extends EventEmitter {
     }
   }
 
-  async auth(token: string) {
+  /**
+   * Authenticate to the server. This is called automatically after a
+   * connection is successfully established.
+   * @param token the API token with which to authenticate
+   */
+  private async auth(token: string) {
     return await new Promise<void>((resolve, reject) => {
       this.send(`auth ${token}`)
       this.once('auth', (ev) => {
@@ -220,32 +334,48 @@ export class Socket extends EventEmitter {
     })
   }
 
-  async subscribe(path: string, cb?: (...args: unknown[]) => void) {
-    if (!path) return
+  /**
+   * Subscribe to an event type.
+   * @param event The name of the event (ex: 'console', 'room:ROOM_NAME')
+   * @param cb The callback to trigger when a relevant message is received.
+   *  This can be left undefined to resubscribe to an event using a
+   *  previously-registered callback.
+   */
+  // TODO: Add overloads with stronger cb type restrictions for known path types
+  async subscribe(event: string, cb?: (...args: unknown[]) => void) {
+    if (!event) return
     const userID = await this.api.userID()
-    if (!(/^(\w+):(.+?)$/.exec(path))) {
-      path = `user:${userID}/${path}`
+    if (!(/^(\w+):(.+?)$/.exec(event))) {
+      event = `user:${userID}/${event}`
     }
     if (this.authed) {
-      this.send(`subscribe ${path}`)
+      this.send(`subscribe ${event}`)
     } else {
-      this.__subQueue.push(`subscribe ${path}`)
+      this.__subQueue.push(`subscribe ${event}`)
     }
-    this.emit('subscribe', path)
-    this.__subs[path] = this.__subs[path] || 0
-    this.__subs[path]++
-    if (cb) this.on(path, cb)
+    this.emit('subscribe', event)
+    this.__subs[event] = this.__subs[event] || 0
+    this.__subs[event]++
+    if (cb) this.on(event, cb)
   }
 
-  async unsubscribe(path: string) {
-    if (!path) return
+  /**
+   * Unsubscribe from an event type.
+   * @param event The name of the event (ex: 'console', 'room:ROOM_NAME')
+   * @param cb The callback to unsubscribe.
+   */
+  async unsubscribe(event: string, cb?: (...args: unknown[]) => void) {
+    if (!event) return
     const userID = await this.api.userID()
-    if (!(/^(\w+):(.+?)$/.exec(path))) {
-      path = `user:${userID}/${path}`
+    if (!(/^(\w+):(.+?)$/.exec(event))) {
+      event = `user:${userID}/${event}`
     }
-    this.send(`unsubscribe ${path}`)
-    this.emit('unsubscribe', path)
-    if (this.__subs[path]) this.__subs[path]--
+    // Unsubscribe is always sent (instead of just at `this.__subs[event] <= 0)
+    // because the server handles subscriber counting already.
+    this.send(`unsubscribe ${event}`)
+    this.emit('unsubscribe', event)
+    if (this.__subs[event]) this.__subs[event]--
+    if (cb) this.off(event, cb)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './ScreepsAPI'
+export { FlagColor } from './Api'


### PR DESCRIPTION
This change is in preparation to add auto-generate API documentation from docblocks using [TypeDoc](https://typedoc.org/).

In order to ensure this generated documentation is useful, docblocks have been added or fleshed out as needed.

In the process of adding documentation, some bugs and incorrect types were discovered and corrected.

Breaking Changes:
* `ScreepsAPI.user.activatePtr()` no longer returns fake responses for non-PTR and unofficial servers.
* Made `ScreepsAPI.socket.reset()` private to prevent users from misusing it and potentially creating a new WebSocket connection without disconnecting the previous ones
* Made `ScreepsAPI.socket.auth()` private now that it triggers automatically
* Made `ScreepsAPI.gz()` private
* Moved `ScreepsAPI.inflate()` to `ScreepsAPI.socket.inflate()` and made it private
* Made several ScreepsAPI.raw function params optional (ex: `name` in `game.createConstruction`)

Improvements:
* Added missing response types for a number of endpoints
* Exported the `FlagColor` enum

Fixes:
* Fixed `Api.ServerListResponse.servers` type (was previously a scalar instead of an array)
* `ScreepsApi.raw` functions no longer throw errors if shard arguments are undefined for unofficial servers, since unofficial servers seem to ignore this argument anyway
* `ScreepsAPI.raw.seasons.current` can now be used on official servers instead of a fake response being returned, since it will return results from these servers as well when a seasonal competition is active
* Fixed swapped `size` and `type` types on `ScreepsAPI.raw.game.createInvader`
* `ScreepsAPI.raw.user.memory.segments.set` now throws an Error if multiple segment IDs are provided to prevent accidental attempts to write multiple segments simultaneously. Otherwise, the server only updates the the first segment and ignores the rest.

Docs:
* Added more documentation for various objects, functions, and types
* Added more documentation