### PR TITLE
docs: Add typedoc external link mapping for AxiosError

### DIFF
--- a/typedoc.jsonc
+++ b/typedoc.jsonc
@@ -29,6 +29,7 @@
   "externalSymbolLinkMappings": {
     "axios": {
       "AxiosResponse": "https://axios.rest/pages/advanced/response-schema",
+      "AxiosError": "https://axios.rest/pages/advanced/error-handling.html",
     },
     "node": {
       "Error": "https://nodejs.org/docs/latest-v24.x/api/errors.html#class-error",


### PR DESCRIPTION
Adds an API docs link for external dependency `AxiosError`