### PR TITLE
chore: Remove unused external dependency from Rollup config

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -17,7 +17,6 @@ export default defineConfig({
   },
   external: [
     'axios',
-    'bluebird',
     'commander',
     'debug',
     'node:events',


### PR DESCRIPTION
`bluebird` is no longer used by this project; removing it from `rollup.config.mjs`