### PR TITLE
fix: Add missing `yarn build` step to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,5 +19,6 @@ jobs:
         registry-url: https://registry.npmjs.org/
         cache: yarn
     - run: yarn install --immutable
+    - run: yarn build
     - run: yarn test
     - run: yarn npm publish --access public


### PR DESCRIPTION
v2.0.0 was published without any sources, type declarations, or source/declaration maps. This change fixes that for future releases.