### PR TITLE
docs: Update docs/examples for RoomEvent

### DIFF
--- a/examples/terminal-client.ts
+++ b/examples/terminal-client.ts
@@ -165,8 +165,14 @@ async function updateRoomObjects(event: RoomEvent) {
 
   gameTime = event.data.gameTime
 
-  // Add/update objects
+  // Add/update/remove objects
   for (const id in event.data.objects) {
+    // Delete removed objects
+    if (event.data.objects[id] === null) {
+      delete objects[id]
+      continue
+    }
+
     // Assign RoomObject properties
     const updated = event.data.objects[id]
     objects[id] ??= updated as RenderedObject
@@ -177,14 +183,6 @@ async function updateRoomObjects(event: RoomEvent) {
     obj.glyph = OBJECT_GLYPHS[obj.type]
     obj.glyphOrder = GLYPH_RENDER_ORDER[obj.type]
   }
-
-  // // Clear old objects:
-  // for (const id in objects) {
-  //   // TODO:
-  //   // - Remove creeps/powerCreeps if gameTime >= obj.gameTime
-  //   // - Check if the value of event.data.objects[id] is null
-  //   //   to indicate a missing object
-  // }
 
   await renderRoom()
   await renderPrompt()

--- a/src/socket/base.ts
+++ b/src/socket/base.ts
@@ -126,10 +126,11 @@ export interface RoomEventData {
    * **Warning:** only the first event returns full room object properties.
    * Subsequent events only return the modified properties.
    *
-   * **Unconfirmed:** values might be null to indicate that the associated object
-   * has disappeared.
+   * When an object ID maps to `null`, this indicates that the object with
+   * that ID has disappeared from the room (i.e. it died, got destroyed, expired,
+   * moved to another room, etc).
    */
-  objects: { [_id: string]: RoomObject }
+  objects: { [_id: string]: RoomObject | null }
   /** {@link https://docs.screeps.com/api/#RoomVisual | RoomVisual} data */
   visual: string
 }


### PR DESCRIPTION
Confirms that values in `RoomEventData.objects` will be null when the associated objects are removed from the room for any reason.