### PR TITLE
feat: Add `GET /api/seasons` endpoint method

### DIFF
--- a/src/ScreepsHttpClient.ts
+++ b/src/ScreepsHttpClient.ts
@@ -1231,8 +1231,23 @@ export class ScreepsHttpClient extends EventEmitter {
   }
 
   /**
-   * Fetch metadata for the current season. Only works on official servers
-   * when a Seasonal World competition is active or about to start.
+   * Fetch a list of all past, current, and upcoming
+   * {@link https://screeps.com/season/#!/seasons/chronicle | Seasonal World} competitions.
+   *
+   * Only works on official servers.
+   * @throws {@link ScreepsApiError} HTTP 404 if called on an unofficial server
+   * @category Endpoints: /seasons
+   */
+  seasonsList(): Promise<Http.SeasonsListResponse> {
+    return this.req(ScreepsHttpMethods.Get, '/api/seasons')
+  }
+
+  /**
+   * Fetch metadata for the current
+   * {@link https://screeps.com/season/#!/seasons/chronicle | Seasonal World} competition.
+   *
+   * Only works on official servers when a Seasonal World competition
+   * is active or about to start.
    *
    * Endpoint: `GET /api/seasons/current`
    * @throws {@link ScreepsApiError} HTTP 404 if called on an unofficial server

--- a/src/http/seasons.ts
+++ b/src/http/seasons.ts
@@ -1,17 +1,47 @@
 import { ScreepsResponse } from './base'
 
 /**
+ * `GET /api/seasons` response
+ * @see {@link ScreepsHttpClient.seasonsList}
+ * @category HTTP API - Seasons
+ */
+export interface SeasonsListResponse extends ScreepsResponse {
+  /**
+   * A list of all past, current, and upcoming Seasonal World competitions,
+   * ordered by {@link SeasonalWorldCompetition.index} (ascending).
+   */
+  list: SeasonalWorldCompetition[]
+}
+
+/**
  * `GET /api/seasons/current` response
  * @see {@link ScreepsHttpClient.seasonsCurrent}
  * @category HTTP API - Seasons
  */
-export interface SeasonsCurrentResponse extends ScreepsResponse {
+export interface SeasonsCurrentResponse extends ScreepsResponse, SeasonalWorldCompetition {
+  /** The authenticated user's current ranking on the seasonal leaderboard */
+  rank: number
+}
+
+/**
+ * Metadata for a
+ * {@link https://screeps.com/season/#!/seasons/chronicle | Seasonal World} competition.
+ * @category HTTP API - Seasons
+ */
+export interface SeasonalWorldCompetition {
+  _id: string
   /** Name of the season (ex: "Season 8") */
   title: string
-  /** Your current ranking on the seasonal leaderboard */
-  rank: number
-  /** The season ordinal (ex: 5 for season 5, 8 for season 8) */
+  /** The season ordinal (ex: 5 for season 5, 8 for season 8, etc) */
   index: number
+  /**
+   * Ostensibly reports the number of participants in the season, but instead,
+   * this is almost always 0
+   *
+   * The only known exception is Season 1, which reports 2121 players.
+   * @see {@link ScoreboardListResponse.meta.length} for an actual player count
+   */
+  players: number
   /** Season start date/time (ISO 8601 UTC) */
   startDate: string
   /** Season end date/time (ISO 8601 UTC) */


### PR DESCRIPTION
`ScreepsHttpClient.seasonsList`: Fetch a list of all past, current, and upcoming Seasonal World competitions.

Sample output:
`yarn run cli call seasonsList` / `screeps-api call seasonsList`:
```json
{
  "ok": 1,
  "list": [
    {
      "_id": "5fa0be4c7e69672e14b58728",
      "index": 1,
      "title": "Season 1",
      "players": 2121,
      "createdAt": "2020-10-01T17:13:07.495Z",
      "updatedAt": "2020-10-01T17:13:07.495Z",
      "startDate": "2020-12-01T00:00:00.000Z",
      "endDate": "2021-02-01T00:00:00.000Z"
    },
    {
      "_id": "6027a69fc48dec25dc7e1f1d",
      "index": 2,
      "title": "Season 2",
      "players": 0,
      "createdAt": "2021-02-15T18:00:00.000Z",
      "updatedAt": "2021-02-15T18:00:00.000Z",
      "startDate": "2021-03-01T18:00:00.000Z",
      "endDate": "2021-05-01T18:00:00.000Z"
    },
    // ... snip ...
    {
      "_id": "699082f4c916952a7e71e9d6",
      "title": "Season 8",
      "createdAt": "2026-02-14T14:00:00.000Z",
      "endDate": "2026-05-01T18:00:00.000Z",
      "index": 8,
      "players": 0,
      "startDate": "2025-03-01T18:00:00.000Z",
      "updatedAt": "2026-02-14T14:00:00.000Z"
    },
    {
      "_id": "6a1dcf58208a4e8e6e090980",
      "title": "Season 10",
      "createdAt": "2026-06-14T14:00:00.000Z",
      "endDate": "2026-08-01T18:00:00.000Z",
      "index": 10,
      "players": 0,
      "startDate": "2025-06-03T18:00:00.000Z",
      "updatedAt": "2026-09-01T14:00:00.000Z"
    }
  ]
}
```