### PR TITLE
feat: Add search param to `ScreepsHttpClient.scoreboardList`

### DIFF
--- a/src/ScreepsHttpClient.ts
+++ b/src/ScreepsHttpClient.ts
@@ -1826,19 +1826,21 @@ export class ScreepsHttpClient extends EventEmitter {
   }
 
   /**
-   * Query scoreboard results. This appears to only be relevant to
+   * Query scoreboard user results. This appears to only be relevant to
    * {@link https://screeps.com/season/#!/seasons/chronicle | Seasonal World}
-   * competitions/events.
+   * competitions.
    *
    * Endpoint: `GET /api/scoreboard/list`
-   * @param offset The index (starting at zero) of the first leaderboard
-   *  position that should be included in the response
-   * @param limit The number of users to return per request.
+   * @param offset Offset of the first result to return
+   * @param limit The maximum number of results to return per request.
    *  The maximum valid value is 20.
+   * @param search If undefined, returns all users. If defined, results are
+   *  filtered by usernames that include this substring (case sensitive).
+   * @throws {@link ScreepsApiError} HTTP 404 if called on a non- Seasonal World server
    * @category Endpoints: /scoreboard
    */
-  scoreboardList(offset = 0, limit = 20): Promise<Http.ScoreboardListResponse> {
-    return this.req(ScreepsHttpMethods.Get, '/api/scoreboard/list', { limit, offset })
+  scoreboardList(offset = 0, limit = 20, search?: string): Promise<Http.ScoreboardListResponse> {
+    return this.req(ScreepsHttpMethods.Get, '/api/scoreboard/list', { limit, offset, search })
   }
 
   /**

--- a/src/http/scoreboard.ts
+++ b/src/http/scoreboard.ts
@@ -8,10 +8,13 @@ import { ScreepsResponse } from './base'
  */
 export interface ScoreboardListResponse extends ScreepsResponse {
   meta: {
-    /** The total number of players who have spawned on this season's map */
+    /** The total number of players in the result set */
     length: number
   }
-  /** A page of player leaderboard results */
+  /**
+   * A page of player scoreboard results
+   * ordered by {@link ScoreboardUser.rank} (ascending)
+   */
   users: ScoreboardUser[]
 }
 


### PR DESCRIPTION
Adds a new `search?: string` param to the end of `ScreepsHttpClient.scoreboardList()`.

Example: `yarn run cli call --server season scoreboardList 0 20 Dr`
```javascript
{
  ok: 1,
  users: [
    {
      username: 'DroidFreak',
      badge: [Object],
      score: 8687050,
      rank: 8
    },
    { username: 'DrDvorak', badge: [Object], score: 6114930, rank: 17 },
    { username: 'Drak', badge: [Object], score: 4689710, rank: 25 },
    { username: 'Dreace', badge: [Object], score: 4638582, rank: 26 },
    {
      username: 'InTeaM_Drake',
      badge: [Object],
      score: 1019060,
      rank: 76
    },
    { username: 'AstralDragon', badge: [Object], rank: 205 },
    { username: 'Dreamfire', badge: [Object], rank: 242 },
    { username: 'Dr_BopoH', badge: [Object], rank: 350 },
    { username: 'DreamIsland', badge: [Object], rank: 351 }
  ],
  meta: { length: 9 }
}
```
