### PR TITLE
Add subscription token resource

### DIFF
--- a/src/common/resources.ts
+++ b/src/common/resources.ts
@@ -196,7 +196,8 @@ export type Resource = typeof Resources[keyof typeof Resources]
 export const IntershardResources = {
   AccessKey: 'accessKey',
   CpuUnlock: 'cpuUnlock',
-  Pixel: 'pixel'
+  Pixel: 'pixel',
+  SubscriptionToken: 'token'
 } as const
 
 /**

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { IntershardResources, MarketResources } from '../../src/index'
+
+test('subscription tokens are intershard market resources', () => {
+  assert.equal(IntershardResources.SubscriptionToken, 'token')
+  assert.equal(MarketResources.SubscriptionToken, 'token')
+})


### PR DESCRIPTION
## What changed

Add `SubscriptionToken: "token"` to `IntershardResources`. It is consequently included in `MarketResources` and the corresponding TypeScript unions.

## Why

The official Screeps constants include `SUBSCRIPTION_TOKEN` as an account-bound resource, but this client omitted it. Callers therefore could not represent token balances or market orders without bypassing the exported resource types.

## Validation

- `yarn lint`
- `yarn build`
- Runtime assertions that both exported resource maps expose `SubscriptionToken` as `token`