### PR TITLE
Fix official server detection

### DIFF
--- a/src/ScreepsHttpClient.ts
+++ b/src/ScreepsHttpClient.ts
@@ -1875,17 +1875,19 @@ export class ScreepsHttpClient extends EventEmitter {
    * or Seasonal World servers
    */
   get isOfficialServer(): boolean {
-    return !!(/screeps\.com/.exec(this.server.url))
+    return new URL(this.server.url).hostname === 'screeps.com'
   }
 
   /** True if this client is configured for the Seasonal World server */
   get isSeasonServer(): boolean {
-    return !!(/screeps\.com\/season/.exec(this.server.url))
+    const url = new URL(this.server.url)
+    return url.hostname === 'screeps.com' && /^\/season(?:\/|$)/.test(url.pathname)
   }
 
   /** True if this client is configured for the Public Test Realm (PTR) server */
   get isPtrServer(): boolean {
-    return !!(/screeps\.com\/ptr/.exec(this.server.url))
+    const url = new URL(this.server.url)
+    return url.hostname === 'screeps.com' && /^\/ptr(?:\/|$)/.test(url.pathname)
   }
 
   protected mapToShard <R extends Response>(

--- a/test/unit/http-client.test.ts
+++ b/test/unit/http-client.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import { ScreepsHttpClient } from '../../src/index'
+
+const client = (url: string) => new ScreepsHttpClient({
+  token: 'test-token',
+  url
+})
+
+describe('official server detection', () => {
+  test('recognizes MMO, PTR, and Seasonal World URLs', () => {
+    assert.equal(client('https://screeps.com/').isOfficialServer, true)
+    assert.equal(client('https://screeps.com:443/ptr/').isPtrServer, true)
+    assert.equal(client('https://screeps.com/season/').isSeasonServer, true)
+  })
+
+  test('rejects deceptive hostnames and paths', () => {
+    for (const url of [
+      'https://my-screeps.com/',
+      'https://screeps.com.example/',
+      'https://example.com/screeps.com/'
+    ]) {
+      assert.equal(client(url).isOfficialServer, false, url)
+    }
+    assert.equal(client('https://screeps.com/ptricious/').isPtrServer, false)
+    assert.equal(client('https://screeps.com/rooms/ptr/').isPtrServer, false)
+  })
+})


### PR DESCRIPTION
## What changed

Parse the configured server URL and classify official, PTR, and Seasonal servers using the exact `screeps.com` hostname and complete path segments.

## Why

The previous regular expressions searched the entire URL for `screeps.com`. They misclassified deceptive hosts such as `my-screeps.com` and `screeps.com.example`, URL paths containing that text, and paths such as `/ptricious`. This changes endpoint behavior intended only for official servers.

## Validation

- `yarn lint`
- `yarn build`
- Assertions covering MMO, PTR, Seasonal, explicit port, deceptive hostnames, hostname text in paths, and partial path-segment matches