### PR TITLE
Fix WebSocket reconnection

### DIFF
--- a/src/ScreepsSocketClient.ts
+++ b/src/ScreepsSocketClient.ts
@@ -244,9 +244,8 @@ export class ScreepsSocketClient extends EventEmitter {
       this.ws = new WebSocket(wsurl)
       this.ws.on('open', () => {
         this.__connected = true
-        this.__reconnecting = false
         if (this.http.appConfig.wsResubscribe) {
-          this.__subQueue.push(...Object.keys(this.__subs))
+          this.__subQueue.push(...Object.keys(this.__subs).map(sub => `subscribe ${sub}`))
         }
         debug(ScreepsSocketClient.CONNECTED)
         this.emit(ScreepsSocketClient.CONNECTED)
@@ -324,8 +323,8 @@ export class ScreepsSocketClient extends EventEmitter {
 
     // Reconnect attempt succeeded
     if (!retry) {
-      // Resume existing subscriptions on the new socket
-      Object.keys(this.__subs).forEach(sub => void this.subscribe(sub))
+      this.__reconnecting = false
+      return
     }
 
     const err = new Error(`Reconnection failed after ${this.http.appConfig.wsReconnectMaxRetries} retries`)

--- a/test/unit/socket-client.test.ts
+++ b/test/unit/socket-client.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import { EventEmitter, once } from 'node:events'
+import { AddressInfo } from 'node:net'
+import { after, before, test } from 'node:test'
+import { WebSocket, WebSocketServer } from 'ws'
+import {
+  DEFAULT_CLIENT_CONFIG,
+  ScreepsHttpClient,
+  ScreepsSocketClient
+} from '../../src/index'
+
+let server: WebSocketServer
+let socket: ScreepsSocketClient
+const connections: WebSocket[] = []
+const messages: string[][] = []
+const received = new EventEmitter()
+
+before(async () => {
+  server = new WebSocketServer({ port: 0, path: '/socket/websocket' })
+  await once(server, 'listening')
+  server.on('connection', ws => {
+    const connectionMessages: string[] = []
+    connections.push(ws)
+    messages.push(connectionMessages)
+    ws.on('message', data => {
+      const message = data.toString()
+      connectionMessages.push(message)
+      received.emit('message')
+      if (message.startsWith('auth ')) ws.send('auth ok test-token')
+    })
+  })
+
+  const { port } = server.address() as AddressInfo
+  const http = new ScreepsHttpClient({
+    app: {
+      ...DEFAULT_CLIENT_CONFIG,
+      wsKeepAlive: false,
+      wsReconnect: false,
+      wsReconnectInitDelay: 0,
+      wsReconnectMaxDelay: 0,
+      wsReconnectMaxRetries: 1
+    },
+    server: {
+      url: `http://127.0.0.1:${port}/`,
+      token: 'test-token'
+    }
+  })
+  socket = http.socket
+})
+
+after(async () => {
+  socket.disconnect()
+  await new Promise<void>(resolve => server.close(() => resolve()))
+})
+
+test('successful reconnect resolves and restores each subscription once', { timeout: 1000 }, async () => {
+  await socket.connect()
+  await socket.subscribe('room:shard0/W1N1')
+
+  const disconnected = once(socket, ScreepsSocketClient.DISCONNECTED)
+  connections[0].close()
+  await disconnected
+
+  await socket.reconnect()
+  while (messages[1].length < 2) await once(received, 'message')
+
+  assert.equal(socket.reconnecting, false)
+  assert.deepEqual(messages[1], [
+    'auth test-token',
+    'subscribe room:shard0/W1N1'
+  ])
+})


### PR DESCRIPTION
## What changed

- Return normally after a successful reconnect instead of falling through to the failure path.
- Keep the reconnect-in-progress flag set until the attempt actually finishes.
- Queue valid `subscribe ...` commands when a connection opens.
- Remove the second explicit subscription pass that duplicated subscription counts and messages.
- Add an offline WebSocket regression test.

## Why

A successful `connect()` set the retry flag to false, but `reconnect()` still constructed, emitted, and threw a failure afterward. Existing subscriptions were also queued without the required command prefix and then subscribed a second time through `subscribe()`.

## Validation

- `yarn lint`
- `yarn tsx --test test/unit/socket-client.test.ts`
- `yarn build`

The regression test uses a local WebSocket server and verifies that reconnect resolves, clears its state, authenticates, and sends exactly one valid resubscription command.