### PR TITLE
Restore the test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "cli": "tsx bin/screeps-api.ts",
     "lint": "eslint",
     "lint-fix": "eslint --fix",
-    "test_": "mocha",
-    "test": "echo Tests disabled, TODO: FIX THIS!",
+    "test": "tsx --test test/unit/*.test.ts",
     "2npm": "publish-if-not-published"
   },
   "author": "Alina Shumann (https://github.com/AlinaNova21)",

--- a/test/unit/config-manager.test.ts
+++ b/test/unit/config-manager.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+import {
+  DEFAULT_CLIENT_CONFIG,
+  ScreepsConfigManager
+} from '../../src/index'
+
+describe('ScreepsConfigManager', () => {
+  const manager = new ScreepsConfigManager()
+
+  test('normalizes URL and token credentials', () => {
+    assert.deepEqual(
+      manager.normalizeServerConfig({
+        token: 'test-token',
+        url: 'https://example.com/screeps'
+      }),
+      {
+        token: 'test-token',
+        url: 'https://example.com/screeps/'
+      }
+    )
+  })
+
+  test('normalizes server aliases and password credentials', () => {
+    assert.deepEqual(
+      manager.normalizeServerConfig({
+        host: 'example.com',
+        password: 'test-password',
+        path: '/screeps',
+        secure: false,
+        username: 'test-user'
+      }),
+      {
+        email: 'test-user',
+        password: 'test-password',
+        url: 'http://example.com/screeps/'
+      }
+    )
+  })
+
+  test('rejects a server without credentials', () => {
+    assert.throws(
+      () => manager.normalizeServerConfig({ url: 'https://example.com' }),
+      /must contain either token or email\/password/
+    )
+  })
+
+  test('merges client overrides with defaults', () => {
+    assert.deepEqual(
+      manager.normalizeClientConfig({}, { wsReconnect: false }),
+      {
+        ...DEFAULT_CLIENT_CONFIG,
+        wsReconnect: false
+      }
+    )
+  })
+})


### PR DESCRIPTION
## What changed

Replace the disabled `yarn test` placeholder with a TypeScript/ESM unit-test command and add four offline configuration-manager tests.

## Why

The current test script always exits successfully after printing that tests are disabled, so CI and release publishing do not execute any assertions. The existing root-level tests target the pre-v2 CommonJS API and require live credentials; the new `test/unit` lane gives current code a reliable offline suite that can be expanded incrementally.

## Validation

- `yarn test` — 4 passing tests
- `yarn lint`
- `yarn build`

The tests cover URL normalization, credential aliases, invalid credentials, and client-option defaults/overrides.