### PR TITLE
fix: correct WebSocket Memory subscription paths

### DIFF
--- a/src/ScreepsSocketClient.ts
+++ b/src/ScreepsSocketClient.ts
@@ -554,13 +554,16 @@ export class ScreepsSocketClient extends EventEmitter {
    *  while using an official server
    * @see {@link unsubscribeUserMemory}
    */
-  async subscribeUserMemory(memoryPath: string, shardName?: string, cb?: (event: UserMemoryEvent) => void) {
-    if (this.http.isOfficialServer) {
-      shardName ??= this.http.appConfig.defaultShard
-      if (!shardName) throw new Error('shardName must be defined')
-      memoryPath = `${shardName}/${memoryPath}`
-    }
-    return this.subscribe(this.userMemoryEventSpec(memoryPath, shardName), cb)
+  async subscribeUserMemory(memoryPath: string, cb?: (event: UserMemoryEvent) => void): Promise<void>
+  async subscribeUserMemory(memoryPath: string, shardName: string, cb?: (event: UserMemoryEvent) => void): Promise<void>
+  async subscribeUserMemory(
+    memoryPath: string,
+    shardNameOrCb?: string | ((event: UserMemoryEvent) => void),
+    cb?: (event: UserMemoryEvent) => void
+  ) {
+    const shardName = typeof shardNameOrCb === 'string' ? shardNameOrCb : undefined
+    const callback = typeof shardNameOrCb === 'function' ? shardNameOrCb : cb
+    return this.subscribe(this.userMemoryEventSpec(memoryPath, shardName), callback)
   }
 
   /**
@@ -573,8 +576,16 @@ export class ScreepsSocketClient extends EventEmitter {
    *  while using an official server
    * @see {@link subscribeUserMemory}
    */
-  async unsubscribeUserMemory(memoryPath: string, shardName?: string, cb?: (event: UserMemoryEvent) => void) {
-    return this.unsubscribe(this.userMemoryEventSpec(memoryPath, shardName), cb)
+  async unsubscribeUserMemory(memoryPath: string, cb?: (event: UserMemoryEvent) => void): Promise<void>
+  async unsubscribeUserMemory(memoryPath: string, shardName: string, cb?: (event: UserMemoryEvent) => void): Promise<void>
+  async unsubscribeUserMemory(
+    memoryPath: string,
+    shardNameOrCb?: string | ((event: UserMemoryEvent) => void),
+    cb?: (event: UserMemoryEvent) => void
+  ) {
+    const shardName = typeof shardNameOrCb === 'string' ? shardNameOrCb : undefined
+    const callback = typeof shardNameOrCb === 'function' ? shardNameOrCb : cb
+    return this.unsubscribe(this.userMemoryEventSpec(memoryPath, shardName), callback)
   }
 
   protected userMemoryEventSpec(

--- a/test/api.socket.ts
+++ b/test/api.socket.ts
@@ -1,0 +1,34 @@
+import assert from 'assert/strict'
+import { ScreepsHttpClient } from 'screeps-api'
+import type { UserMemoryEvent } from '../src/socket/user.js'
+
+describe('ScreepsSocketClient memory subscriptions', function () {
+  it('supports the documented path and callback form', async function () {
+    const api = new ScreepsHttpClient({ token: 'test-token' })
+    api.appConfig.defaultShard = 'shard0'
+    const socket = api.socket
+    let eventSpec: string | undefined
+    const callback = (_event: UserMemoryEvent) => {}
+    ;(socket as any).subscribe = async (spec: string) => {
+      eventSpec = spec
+    }
+
+    await socket.subscribeUserMemory('remoteMining', callback)
+
+    assert.equal(eventSpec, 'memory/shard0/remoteMining')
+  })
+
+  it('supports an explicit shard without duplicating it', async function () {
+    const api = new ScreepsHttpClient({ token: 'test-token' })
+    const socket = api.socket
+    let eventSpec: string | undefined
+    const callback = (_event: UserMemoryEvent) => {}
+    ;(socket as any).subscribe = async (spec: string) => {
+      eventSpec = spec
+    }
+
+    await socket.subscribeUserMemory('remoteMining', 'shard2', callback)
+
+    assert.equal(eventSpec, 'memory/shard2/remoteMining')
+  })
+})


### PR DESCRIPTION
## What changed

Fix `subscribeUserMemory()` and `unsubscribeUserMemory()` so the documented `(memoryPath, callback)` form works, the explicit `(memoryPath, shardName, callback)` form remains supported, and the shard is added exactly once to the WebSocket event path.

## Why

On official servers, the previous implementation prefixed the shard in both `subscribeUserMemory()` and `userMemoryEventSpec()`. For example, `subscribeUserMemory('remoteMining', 'shard2', callback)` produced `memory/shard2/shard2/remoteMining` instead of `memory/shard2/remoteMining`.

The README documents `(memoryPath, callback)`, but the implementation interpreted the callback as `shardName`.

## Tests

Added unit coverage for both callback usage and explicit shard usage.

Validation: `npm run typecheck:test`, `npm run build`, and `TSX_TSCONFIG_PATH=test/tsconfig.json npx mocha` (28 passing, 1 pending on Windows). Targeted ESLint on changed source passed; repository-wide lint still reports the existing `bin/screeps-api.ts` `unbound-method` error.
